### PR TITLE
refactor: modify output directories

### DIFF
--- a/workflow/rules/prepare.smk
+++ b/workflow/rules/prepare.smk
@@ -57,7 +57,6 @@ rule trim_genome_seq_id:
     output:
         genome=os.path.join(config["output_dir"], "genome.processed.fa"),
     params:
-        dir_out=lambda wildcards, output: output[0][:-4],
         cluster_log=os.path.join(
             config["cluster_log"],
             "genome_process.log",
@@ -297,7 +296,7 @@ rule gfftobed:
         bed=os.path.join(config["output_dir"], "mirna_annotations.bed"),
     params:
         cluster_log=os.path.join(config["cluster_log"], "gfftobed.log"),
-        out_dir=lambda wildcards, input: input[0][:-4],
+        out_dir=lambda wildcards, input: input[0][:-21],
     log:
         os.path.join(config["local_log"], "gfftobed.log"),
     container:

--- a/workflow/rules/prepare.smk
+++ b/workflow/rules/prepare.smk
@@ -296,7 +296,7 @@ rule gfftobed:
         bed=os.path.join(config["output_dir"], "mirna_annotations.bed"),
     params:
         cluster_log=os.path.join(config["cluster_log"], "gfftobed.log"),
-        out_dir=lambda wildcards, input: input[0][:-21],
+        out_dir=lambda wildcards, input: input[0][:-22],
     log:
         os.path.join(config["local_log"], "gfftobed.log"),
     container:

--- a/workflow/rules/prepare.smk
+++ b/workflow/rules/prepare.smk
@@ -9,6 +9,8 @@
 
 import os
 
+from pathlib import Path
+
 ###############################################################################
 ### Global configuration
 ###############################################################################
@@ -296,7 +298,7 @@ rule gfftobed:
         bed=os.path.join(config["output_dir"], "mirna_annotations.bed"),
     params:
         cluster_log=os.path.join(config["cluster_log"], "gfftobed.log"),
-        out_dir=lambda wildcards, input: input[0][:-22],
+        out_dir=lambda wildcards, input: Path(input[0]).parent,
     log:
         os.path.join(config["local_log"], "gfftobed.log"),
     container:


### PR DESCRIPTION
The first line has to be removed because it does nothing.
The second line, has been changed to match the output directory; before, it was creating a directory named `.mirna_annotations`.