### PR TITLE
fix: remove duplicate alignments

### DIFF
--- a/scripts/sam_remove_duplicates_inferior_alignments_multimappers.pl
+++ b/scripts/sam_remove_duplicates_inferior_alignments_multimappers.pl
@@ -271,15 +271,12 @@ sub sam_AoH_filter_records_w_ident_QNAME {
 			my $edit_distance = ($hash_ref->{"NM"} =~ /^.*:(\d+)/)[0];
 			$min_edit_distance = $edit_distance if ! defined $min_edit_distance || $edit_distance < $min_edit_distance;
 			push @edit_distances, $edit_distance;
+			my $alignment_type = ($hash_ref->{"FLAG"} & 0x10) ? 16 : 0;																			# Set FLAG to 0 or 16 (reversed complementary)
+       		$hash_ref->{"FLAG"} = $alignment_type;
 		}	
 		for ( my $index = $#edit_distances; $index >= 0; $index-- ) {
 			splice @$AoH_ref, $index, 1 if $edit_distances[$index] != $min_edit_distance; 
 		}
-
-		foreach my $hash_ref (@$AoH_ref) {
-        	my $alignment_type = ($hash_ref->{"FLAG"} & 0x10) ? 16 : 0;										# Set FLAG to 0 or 16 (reversed complementary)
-       		$hash_ref->{"FLAG"} = $alignment_type;
-    	}
 	
 	#---> RETURN VALUE <---#
 	return $AoH_ref;

--- a/scripts/sam_remove_duplicates_inferior_alignments_multimappers.pl
+++ b/scripts/sam_remove_duplicates_inferior_alignments_multimappers.pl
@@ -183,7 +183,7 @@ sub filter_sam {
 				$fields{$tag} = $value;
 			}
 			
-			 next if ($fields{"FLAG"} & 0x4); 																		# Skip the line if the sequence is unmapped
+			next if ($fields{"FLAG"} & 0x4); 																	# Skip the line if the sequence is unmapped
 			 
 			die "[ERROR] Edit distance ('NM tag') missing!" unless defined $fields{"NM"};						# Assert presence of NM tag
 
@@ -256,10 +256,10 @@ sub sam_AoH_filter_records_w_ident_QNAME {
 	
 	#---> BODY <---#
 
-		#---> Remove "true duplicates" (same QNAME, FLAG, RNAME, POS & CIGAR) / KEEP ONE!!! <---#
+		#---> Remove "true duplicates" (same QNAME, 0x10 bit in FLAG, RNAME, POS & CIGAR) / KEEP ONE!!! <---#
 		my %true_dup;
 		for my $hash_ref (@$AoH_ref) {
-			my $id_coord = join "", $hash_ref->{"QNAME"}, $hash_ref->{"FLAG"}, $hash_ref->{"RNAME"}, $hash_ref->{"POS"}, $hash_ref->{"CIGAR"};	# make string to unambiguously define mapping position
+			my $id_coord = join "", $hash_ref->{"QNAME"}, ($hash_ref->{"FLAG"} & 0x10), $hash_ref->{"RNAME"}, $hash_ref->{"POS"}, $hash_ref->{"CIGAR"};	# make string to unambiguously define mapping position
 			$true_dup{$id_coord} = $hash_ref;																									# Add to hash
 		}
 		$AoH_ref = [values %true_dup];	
@@ -274,7 +274,12 @@ sub sam_AoH_filter_records_w_ident_QNAME {
 		}	
 		for ( my $index = $#edit_distances; $index >= 0; $index-- ) {
 			splice @$AoH_ref, $index, 1 if $edit_distances[$index] != $min_edit_distance; 
-		}		
+		}
+
+		foreach my $hash_ref (@$AoH_ref) {
+        	my $alignment_type = ($hash_ref->{"FLAG"} & 0x10) ? 16 : 0;										# Set FLAG to 0 or 16 (reversed complementary)
+       		$hash_ref->{"FLAG"} = $alignment_type;
+    	}
 	
 	#---> RETURN VALUE <---#
 	return $AoH_ref;


### PR DESCRIPTION
In this PR the script `sam_remove_duplicates_inferior_alignments_multimappers.pl` considers only the `0x10` bit in the FLAG field  when deciding if reads are identical (together with the same ID, same reference sequence, same starting position, same sequence, same CIGAR and same MD). 
In addition,  all secondary and supplementary etc bits in the output are unset and only either 0 or 16 (reverse complemented) is used.  

These changes have been applied as the pipeline had as output the following alignments

```
67-2_3 0 19 34588 255 21M * 0 0 CCTCTACAGGGAAGCGCTTTC * MD:Z:21 NM:i:0 NH:i:3 HI:i:1 YW:Z:hsa-miR-520b-5p|0|0|21M|21
67-2_3 0 19 95718 255 21M * 0 0 CCTCTACAGGGAAGCGCTTTC * MD:Z:21 NM:i:0 NH:i:3 HI:i:2 YW:Z:hsa-miR-519a-2-5p|0|0|21M|21
67-2_3 256 19 95718 1 21M * 0 0 CCTCTACAGGGAAGCGCTTTC * MD:Z:21 NM:i:0 NH:i:3 HI:i:3 YW:Z:hsa-miR-519a-2-5p|0|0|21M|21
```
In this trio, the second alignment is defined as a primary alignment (FLAG = 0) with a QMAP of 255 whereas the third alignment is considered a secondary alignment (FLAG = 256) with a QMAP of 0. Even if they are duplicate entries (same starting position, sequence, CIGAR and MD), due to these differences they are treated as different.
After applying the changes, the resulting alignments are:

```
67-2_2	0	19	34588	255	21M	*	0	0	CCTCTACAGGGAAGCGCTTTC	*	MD:Z:21	NM:i:0	NH:i:2	HI:i:1	YW:Z:hsa-miR-520b-5p|0|0|21M|21
67-2_2	0	19	95718	255	21M	*	0	0	CCTCTACAGGGAAGCGCTTTC	*	MD:Z:21	NM:i:0	NH:i:2	HI:i:2	YW:Z:hsa-miR-519a-2-5p|0|0|21M|21
```