### PR TITLE
fix: update FASTX Toolkit image labels

### DIFF
--- a/workflow/rules/map.smk
+++ b/workflow/rules/map.smk
@@ -118,7 +118,7 @@ rule fastq_quality_filter:
     log:
         LOCAL_LOG / "fastq_quality_filter_{sample}.log",
     container:
-        "docker://quay.io/biocontainers/fastx_toolkit:0.0.14--H87F3376_10"
+        "docker://quay.io/biocontainers/fastx_toolkit:0.0.14--h87f3376_10"
     conda:
         ENV_DIR / "fastx_toolkit.yaml"
     shell:
@@ -146,7 +146,7 @@ rule fastq_to_fasta:
     log:
         LOCAL_LOG / "fastq_to_fasta_{sample}.log",
     container:
-        "docker://quay.io/biocontainers/fastx_toolkit:0.0.14--H87F3376_10"
+        "docker://quay.io/biocontainers/fastx_toolkit:0.0.14--h87f3376_10"
     conda:
         ENV_DIR / "fastx_toolkit.yaml"
     shell:
@@ -171,7 +171,7 @@ rule format_fasta:
     log:
         LOCAL_LOG / "format_fasta_{sample}.log",
     container:
-        "docker://quay.io/biocontainers/fastx_toolkit:0.0.14--H87F3376_10"
+        "docker://quay.io/biocontainers/fastx_toolkit:0.0.14--h87f3376_10"
     conda:
         ENV_DIR / "fastx_toolkit.yaml"
     shell:
@@ -230,7 +230,7 @@ rule collapse_identical_reads:
     log:
         LOCAL_LOG / "collapse_identical_reads_{sample}.log",
     container:
-        "docker://quay.io/biocontainers/fastx_toolkit:0.0.14--H87F3376_10"
+        "docker://quay.io/biocontainers/fastx_toolkit:0.0.14--h87f3376_10"
     conda:
         ENV_DIR / "fastx_toolkit.yaml"
     shell:


### PR DESCRIPTION
Fixed #122.

The tag for the `fastx_toolkit` image has been set to lower-case.