### PR TITLE
style:  change unit test scripts for `flake8`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: flake8
         working-directory: ./scripts
-        run: flake8 ./*.py
+        run: flake8 --ignore=E402
 
       - name: mypy
         working-directory: ./scripts

--- a/scripts/tests/test_filter_multimappers.py
+++ b/scripts/tests/test_filter_multimappers.py
@@ -22,7 +22,7 @@ from scripts.filter_multimappers import (
 def sam_empty_file():
     """Import path to empty test file."""
     empty_file = Path("files/header_only.sam")
-    
+
     return empty_file
 
 
@@ -42,6 +42,7 @@ def sam_no_multimappers_file():
 
     return no_multi
 
+
 @pytest.fixture
 def sam_unique_diff_multimappers_files():
     """Import path to test files with a single multimapper."""
@@ -49,6 +50,7 @@ def sam_unique_diff_multimappers_files():
     out_diff_multi = Path("files/diff_multimappers.sam")
 
     return in_diff_multi, out_diff_multi
+
 
 @pytest.fixture
 def sam_unique_equal_multimapper_files():
@@ -58,21 +60,19 @@ def sam_unique_equal_multimapper_files():
 
     return in_sam, out_sam
 
+
 @pytest.fixture
 def sam_sec_sup_files():
-    """
-    Import path to the test files with secondary and supplementary alignments.
-    """
+    """Import path to the test files with secondary and supp. alignments."""
     in_sam = Path("files/in_sec_sup.sam")
     out_sam = Path("files/sec_sup.sam")
 
     return in_sam, out_sam
 
+
 @pytest.fixture
 def sam_multimappers_nh_files():
-    """
-    Import path to test files with multimappers and the NH tag in the query name.
-    """
+    """Import path to test files with multimappers and NH tag in the name."""
     in_multimappers = Path("files/in_multimappers.sam")
     out_multimappers = Path("files/multimappers_nh.sam")
 
@@ -163,7 +163,7 @@ class TestParseArguments:
         )
         args = parse_arguments().parse_args()
         assert isinstance(args, argparse.Namespace)
-    
+
     def test_all_input_options(self, monkeypatch, sam_no_multimappers_file):
         """Call with a single input file and the --nh option."""
         sam_1 = sam_no_multimappers_file
@@ -236,7 +236,7 @@ class TestFindBestAlignments:
         assert output[1].get_tag("NH") == 2
         assert output[0].get_tag("HI") == 1
         assert output[1].get_tag("HI") == 2
-    
+
     def test_find_best_alignments_multimappers_nh(self, alns):
         """Test function with multimappers with different indel count."""
         output = find_best_alignments([alns[0], alns[1]], True)
@@ -274,13 +274,13 @@ class TestWriteOutout:
 
         with pysam.AlignmentFile(in_sam, 'r') as in_file:
             alignment = next(in_file)
-        
+
         write_output([alignment])
         captured = capsys.readouterr()
 
         with pysam.AlignmentFile(out_sam, 'r') as out_file:
             out_alignment = next(out_file)
-        
+
         assert captured.out == out_alignment.to_string() + '\n'
 
 
@@ -304,7 +304,8 @@ class TestMain:
         with open(empty_file, 'r') as out_file:
             assert captured.out == out_file.read()
 
-    def test_main_multimappers(self, capsys, monkeypatch, sam_multimappers_files):
+    def test_main_multimappers(self, capsys, monkeypatch,
+                               sam_multimappers_files):
         """Test main function with multimappers."""
         in_sam, out_sam = sam_multimappers_files
 
@@ -321,7 +322,8 @@ class TestMain:
         with open(out_sam, 'r') as out_file:
             assert captured.out == out_file.read()
 
-    def test_main_multimappers_nh(self, capsys, monkeypatch, sam_multimappers_nh_files):
+    def test_main_multimappers_nh(self, capsys, monkeypatch,
+                                  sam_multimappers_nh_files):
         """Test main function with multimappers with nh argument."""
         in_sam, out_sam = sam_multimappers_nh_files
 
@@ -339,7 +341,8 @@ class TestMain:
         with open(out_sam, 'r') as out_file:
             assert captured.out == out_file.read()
 
-    def test_main_no_multimappers(self, capsys, monkeypatch, sam_no_multimappers_file):
+    def test_main_no_multimappers(self, capsys, monkeypatch,
+                                  sam_no_multimappers_file):
         """Test main function with no multimappers."""
         sam_file = sam_no_multimappers_file
 
@@ -355,8 +358,9 @@ class TestMain:
 
         with open(sam_file, 'r') as out_file:
             assert captured.out == out_file.read()
-    
-    def test_main_secondary_supplementary(self, capsys, monkeypatch, sam_sec_sup_files):
+
+    def test_main_secondary_supplementary(self, capsys, monkeypatch,
+                                          sam_sec_sup_files):
         """Test main function with secondary and supplementary alignments."""
         in_sam, out_sam = sam_sec_sup_files
 

--- a/scripts/tests/test_iso_name_tagging.py
+++ b/scripts/tests/test_iso_name_tagging.py
@@ -69,7 +69,7 @@ class TestParseArguments:
             )
             parse_arguments().parse_args()
         assert sysex.value.code == 2
-    
+
     def test_no_sam(self, monkeypatch, bed_sam):
         """Call without bed file."""
         in_bed, in_sam, output = bed_sam
@@ -97,7 +97,7 @@ class TestParseArguments:
         )
         args = parse_arguments().parse_args()
         assert isinstance(args, argparse.Namespace)
-    
+
     def test_all_input(self, monkeypatch, bed_sam):
         """Call with all the options."""
         in_bed, in_sam, output = bed_sam
@@ -118,7 +118,8 @@ class TestParseArguments:
 class TestMain:
     """Test 'main()' function."""
 
-    def test_main_empty_bed_file(self, monkeypatch, capsys, empty_files, bed_sam):
+    def test_main_empty_bed_file(self, monkeypatch, capsys, empty_files,
+                                 bed_sam):
         """Test main function with an empty bed file."""
         empty_bed, empty_sam = empty_files
 
@@ -136,7 +137,8 @@ class TestMain:
         with open(empty_sam, 'r') as out_file:
             assert captured.out == out_file.read()
 
-    def test_main_empty_sam_file(self, monkeypatch, capsys, empty_files, bed_sam):
+    def test_main_empty_sam_file(self, monkeypatch, capsys, empty_files,
+                                 bed_sam):
         """Test main function with an empty sam file."""
         empty_bed, empty_sam = empty_files
         in_bed, in_sam, output = bed_sam
@@ -154,7 +156,6 @@ class TestMain:
 
         with open(empty_sam, 'r') as out_file:
             assert captured.out == out_file.read()
-    
 
     def test_main_bed_sam_file(self, monkeypatch, capsys, bed_sam):
         """Test main function without options."""
@@ -173,8 +174,9 @@ class TestMain:
 
         with open(output, 'r') as out_file:
             assert captured.out == out_file.read()
-    
-    def test_main_bed_sam_extension_file(self, monkeypatch, capsys, bed_sam_extension):
+
+    def test_main_bed_sam_extension_file(self, monkeypatch, capsys,
+                                         bed_sam_extension):
         """Test main function with extension equals 6."""
         in_bed, in_sam, output = bed_sam_extension
 
@@ -193,7 +195,7 @@ class TestMain:
         with open(output, 'r') as out_file:
             assert captured.out == out_file.read()
 
-    def test_main_bed_sam_file(self, monkeypatch, capsys, bed_sam_id):
+    def test_main_bed_sam_file_id(self, monkeypatch, capsys, bed_sam_id):
         """Test main function with id equals id."""
         in_bed, in_sam, output = bed_sam_id
 

--- a/scripts/tests/test_mirna_extension.py
+++ b/scripts/tests/test_mirna_extension.py
@@ -9,8 +9,7 @@ import pytest
 
 sys.path.append("../../")
 
-
-from scripts.mirna_extension import(
+from scripts.mirna_extension import (
     main,
     MirnaExtension,
     parse_arguments
@@ -41,7 +40,7 @@ def gff_extremes():
     in_extremes = Path("files/in_mirna_extreme_mirs.gff3")
     out_primir = Path("files/extreme_primir_anno.gff3")
     out_mir = Path("files/extreme_mir_anno.gff3")
-    
+
     return in_extremes, out_primir, out_mir
 
 
@@ -52,7 +51,7 @@ def gff_extremes_chr():
     in_chr_extremes = Path("files/in_mirna_extreme_chr_mirs.gff3")
     out_primir = Path("files/extreme_chr_primir_anno.gff3")
     out_mir = Path("files/extreme_chr_mir_anno.gff3")
-    
+
     return chr_size, in_chr_extremes, out_primir, out_mir
 
 
@@ -76,11 +75,11 @@ class TestParseArguments:
         monkeypatch.setattr(
             sys, 'argv',
             ['mirna_extension',
-              str(gff_in),
-              '--outdir', str(tmp_path),
+             str(gff_in),
+             '--outdir', str(tmp_path),
              ]
         )
-        
+
         args = parse_arguments().parse_args()
         assert isinstance(args, argparse.Namespace)
 
@@ -97,7 +96,7 @@ class TestParseArguments:
              '--extension', '6',
              ]
         )
-        
+
         args = parse_arguments().parse_args()
         assert isinstance(args, argparse.Namespace)
 
@@ -109,9 +108,9 @@ class TestMain:
         """Test main function with an empty file."""
         gff_empty = gff_empty
 
-        primir_out = tmp_path/"extended_primir_annotation_6_nt.gff3"
-        mir_out = tmp_path/"extended_mirna_annotation_6_nt.gff3"
-        
+        primir_out = tmp_path / "extended_primir_annotation_6_nt.gff3"
+        mir_out = tmp_path / "extended_mirna_annotation_6_nt.gff3"
+
         monkeypatch.setattr(
             sys, 'argv',
             ['mirna_extension',
@@ -123,19 +122,18 @@ class TestMain:
         main(args)
 
         with open(gff_empty, 'r') as expected, open(primir_out, 'r') as output:
-            assert output.read() == expected.read() 
-        
-        with open(gff_empty, 'r') as expected, open(mir_out, 'r') as output:
-            assert output.read() == expected.read() 
+            assert output.read() == expected.read()
 
-            
-    
-    def test_main_no_extreme_coords(self, monkeypatch, tmp_path, gff_no_extremes):
+        with open(gff_empty, 'r') as expected, open(mir_out, 'r') as output:
+            assert output.read() == expected.read()
+
+    def test_main_no_extreme_coords(self, monkeypatch, tmp_path,
+                                    gff_no_extremes):
         """Test main function with no extreme coords."""
         in_gff, pre_gff, mir_gff = gff_no_extremes
 
-        primir_out = tmp_path/"extended_primir_annotation_6_nt.gff3"
-        mir_out = tmp_path/"extended_mirna_annotation_6_nt.gff3"
+        primir_out = tmp_path / "extended_primir_annotation_6_nt.gff3"
+        mir_out = tmp_path / "extended_mirna_annotation_6_nt.gff3"
 
         monkeypatch.setattr(
             sys, 'argv',
@@ -148,17 +146,17 @@ class TestMain:
         main(args)
 
         with open(pre_gff, 'r') as expected, open(primir_out, 'r') as output:
-            assert output.read() == expected.read() 
-        
+            assert output.read() == expected.read()
+
         with open(mir_gff, 'r') as expected, open(mir_out, 'r') as output:
-            assert output.read() == expected.read() 
+            assert output.read() == expected.read()
 
     def test_main_extreme_coords(self, monkeypatch, tmp_path, gff_extremes):
         """Test main function with extreme coords."""
         in_gff, pre_gff, mir_gff = gff_extremes
 
-        primir_out = tmp_path/"extended_primir_annotation_6_nt.gff3"
-        mir_out = tmp_path/"extended_mirna_annotation_6_nt.gff3"
+        primir_out = tmp_path / "extended_primir_annotation_6_nt.gff3"
+        mir_out = tmp_path / "extended_mirna_annotation_6_nt.gff3"
 
         monkeypatch.setattr(
             sys, 'argv',
@@ -171,17 +169,18 @@ class TestMain:
         main(args)
 
         with open(pre_gff, 'r') as expected, open(primir_out, 'r') as output:
-            assert output.read() == expected.read() 
+            assert output.read() == expected.read()
 
         with open(mir_gff, 'r') as expected, open(mir_out, 'r') as output:
-            assert output.read() == expected.read() 
+            assert output.read() == expected.read()
 
-    def test_main_extreme_coords(self, monkeypatch, tmp_path, gff_extremes_chr):
+    def test_main_extreme_coords_limit_size(self, monkeypatch, tmp_path,
+                                            gff_extremes_chr):
         """Test main function with extreme coords and limited by chr size."""
         chr_size, in_gff, pre_gff, mir_gff = gff_extremes_chr
 
-        primir_out = tmp_path/"extended_primir_annotation_6_nt.gff3"
-        mir_out = tmp_path/"extended_mirna_annotation_6_nt.gff3"
+        primir_out = tmp_path / "extended_primir_annotation_6_nt.gff3"
+        mir_out = tmp_path / "extended_mirna_annotation_6_nt.gff3"
 
         monkeypatch.setattr(
             sys, 'argv',
@@ -195,10 +194,11 @@ class TestMain:
         main(args)
 
         with open(pre_gff, 'r') as expected, open(primir_out, 'r') as output:
-            assert output.read() == expected.read() 
+            assert output.read() == expected.read()
 
         with open(mir_gff, 'r') as expected, open(mir_out, 'r') as output:
-            assert output.read() == expected.read() 
+            assert output.read() == expected.read()
+
 
 class TestLoadGffFile():
     """Test for the 'load_gff_file' method."""
@@ -212,10 +212,11 @@ class TestLoadGffFile():
 
         assert mirnaObject is not None
         assert isinstance(mirnaObject.db, gffutils.FeatureDB)
-        assert len(list(mirnaObject.db.features_of_type("miRNA_primary_transcript"))) == 2
+        assert len(list(
+            mirnaObject.db.features_of_type("miRNA_primary_transcript"))) == 2
         assert len(list(mirnaObject.db.features_of_type("miRNA"))) == 3
 
-    def test_load_gff_file(self, monkeypatch, gff_no_extremes):
+    def test_load_gff_file_std(self, monkeypatch, gff_no_extremes):
         """Test input loading from standard input."""
         in_file, pre_exp, mir_exp = gff_no_extremes
         monkeypatch.setattr(sys, 'stdin', str(in_file))
@@ -225,7 +226,8 @@ class TestLoadGffFile():
 
         assert mirnaObject is not None
         assert isinstance(mirnaObject.db, gffutils.FeatureDB)
-        assert len(list(mirnaObject.db.features_of_type("miRNA_primary_transcript"))) == 2
+        assert len(list(
+            mirnaObject.db.features_of_type("miRNA_primary_transcript"))) == 2
         assert len(list(mirnaObject.db.features_of_type("miRNA"))) == 3
 
 
@@ -236,42 +238,43 @@ class TestExtendMirnas:
         """Test miRNA extension with no extreme coordinates."""
         in_file, pre_exp, mir_exp = gff_no_extremes
 
-        primir_out = tmp_path/"extended_primir_annotation_6_nt.gff3"
-        mir_out = tmp_path/"extended_mirna_annotation_6_nt.gff3"
+        primir_out = tmp_path / "extended_primir_annotation_6_nt.gff3"
+        mir_out = tmp_path / "extended_mirna_annotation_6_nt.gff3"
 
         mirnaObject = MirnaExtension()
         mirnaObject.load_gff_file(str(in_file))
         mirnaObject.extend_mirnas(primir_out=primir_out, mir_out=mir_out)
 
         with open(primir_out, 'r') as output, open(pre_exp, 'r') as expected:
-            assert output.read() == expected.read() 
-        
+            assert output.read() == expected.read()
+
         with open(mir_out, 'r') as output, open(mir_exp, 'r') as expected:
             assert output.read() == expected.read()
-    
+
     def test_extend_mirnas_extreme_coords(self, tmp_path, gff_extremes):
         """Test miRNA extension with miRNAs having extreme coordinates."""
         in_file, pre_exp, mir_exp = gff_extremes
 
-        primir_out = tmp_path/"extended_primir_annotation_6_nt.gff3"
-        mir_out = tmp_path/"extended_mirna_annotation_6_nt.gff3"
+        primir_out = tmp_path / "extended_primir_annotation_6_nt.gff3"
+        mir_out = tmp_path / "extended_mirna_annotation_6_nt.gff3"
 
         mirnaObject = MirnaExtension()
         mirnaObject.load_gff_file(str(in_file))
         mirnaObject.extend_mirnas(primir_out=primir_out, mir_out=mir_out)
 
         with open(primir_out, 'r') as output, open(pre_exp, 'r') as expected:
-            assert output.read() == expected.read() 
-        
+            assert output.read() == expected.read()
+
         with open(mir_out, 'r') as output, open(mir_exp, 'r') as expected:
             assert output.read() == expected.read()
 
-    def test_extend_mirnas_no_extreme_coords(self, tmp_path, gff_extremes_chr):
+    def test_extend_mirnas_extreme_coords_chr_boundaries(self, tmp_path,
+                                                         gff_extremes_chr):
         """Test miRNA extension with extreme coordinates and chr boundaries."""
         chr_size, in_file, pre_exp, mir_exp = gff_extremes_chr
 
-        primir_out = tmp_path/"extended_primir_annotation_6_nt.gff3"
-        mir_out = tmp_path/"extended_mirna_annotation_6_nt.gff3"
+        primir_out = tmp_path / "extended_primir_annotation_6_nt.gff3"
+        mir_out = tmp_path / "extended_mirna_annotation_6_nt.gff3"
 
         len_dict = {}
         with open(chr_size, 'r') as f:
@@ -286,7 +289,7 @@ class TestExtendMirnas:
                                   seq_lengths=len_dict)
 
         with open(primir_out, 'r') as output, open(pre_exp, 'r') as expected:
-            assert output.read() == expected.read() 
-        
+            assert output.read() == expected.read()
+
         with open(mir_out, 'r') as output, open(mir_exp, 'r') as expected:
             assert output.read() == expected.read()

--- a/scripts/tests/test_mirna_quantification.py
+++ b/scripts/tests/test_mirna_quantification.py
@@ -85,7 +85,7 @@ def read_sam_file():
 
 @pytest.fixture
 def read_len_sam_file():
-    """Import path to test files with read IDs and feature len in the output table."""
+    """Import path to test files with read IDs and len in the output table."""
     sam_file = Path("files/in_aln_tag.sam")
     out_table = Path("files/len_ids_iso_mirna_quantification")
 
@@ -223,11 +223,11 @@ class TestGetContribution():
 
     def test_collapsed_nh(self, alns):
         """Test collapsed alignment with NH in the name."""
-        assert collapsed_nh_contribution(alns[0]) == 2/3
+        assert collapsed_nh_contribution(alns[0]) == 2 / 3
 
     def test_uncollpased_nh(self, alns):
         """Test uncollapsed alignment with NH in the name."""
-        assert nh_contribution(alns[1]) == 1/4
+        assert nh_contribution(alns[1]) == 1 / 4
 
     def test_collapsed_no_nh(self, alns):
         """Test collapsed alignment without NH in the name."""
@@ -235,7 +235,7 @@ class TestGetContribution():
 
     def test_uncollpased_no_nh(self, alns):
         """Test uncollapsed alignment without NH in the name."""
-        assert contribution(alns[3]) == 1/8
+        assert contribution(alns[3]) == 1 / 8
 
     def test_uncollpased_missing_nh(self, alns):
         """Test uncollapsed alignment with missing NH value."""
@@ -267,7 +267,7 @@ class TestMain:
     def test_main_empty_sam_file(self, monkeypatch, tmp_path, empty_file):
         """Test main function with an empty SAM file."""
         empty_in, empty_out = empty_file
-        output = tmp_path/"mirna_counts_lib"
+        output = tmp_path / "mirna_counts_lib"
 
         monkeypatch.setattr(
             sys, 'argv',
@@ -285,7 +285,7 @@ class TestMain:
     def test_main_isomir_mirna_sam_file(self, monkeypatch, tmp_path, sam_file):
         """Test main function with complete SAM file."""
         infile, out_table = sam_file
-        output = tmp_path/"mirna_counts_lib"
+        output = tmp_path / "mirna_counts_lib"
 
         monkeypatch.setattr(
             sys, 'argv',
@@ -302,10 +302,11 @@ class TestMain:
         with open(out_table, 'r') as expected, open(output, 'r') as out_file:
             assert out_file.read() == expected.read()
 
-    def test_main_iso_sam_file(self, monkeypatch, tmp_path, iso_mirna_sam_file):
+    def test_main_iso_sam_file(self, monkeypatch, tmp_path,
+                               iso_mirna_sam_file):
         """Test main function tabulating only isomiRs."""
         infile, iso_out_table, mirna_out_table = iso_mirna_sam_file
-        mirna_output = tmp_path/"mirna_counts_lib"
+        mirna_output = tmp_path / "mirna_counts_lib"
 
         monkeypatch.setattr(
             sys, 'argv',
@@ -320,13 +321,15 @@ class TestMain:
         args = parse_arguments().parse_args()
         main(args)
 
-        with open(iso_out_table, 'r') as expected, open(mirna_output, 'r') as out_file:
+        with (open(iso_out_table, 'r') as expected,
+              open(mirna_output, 'r') as out_file):
             assert out_file.read() == expected.read()
 
-    def test_main_mirna_sam_file(self, monkeypatch, tmp_path, iso_mirna_sam_file):
+    def test_main_mirna_sam_file(self, monkeypatch, tmp_path,
+                                 iso_mirna_sam_file):
         """Test main function tabulating only canonical miRNA."""
         infile, iso_out_table, mirna_out_table = iso_mirna_sam_file
-        mirna_output = tmp_path/"mirna_counts_lib"
+        mirna_output = tmp_path / "mirna_counts_lib"
 
         monkeypatch.setattr(
             sys, 'argv',
@@ -335,19 +338,21 @@ class TestMain:
              '--collapsed',
              '--nh',
              '--outdir', str(tmp_path),
-             '--mir-list',  "mirna"
+             '--mir-list', "mirna"
              ]
         )
         args = parse_arguments().parse_args()
         main(args)
 
-        with open(mirna_out_table, 'r') as expected, open(mirna_output, 'r') as out_file:
+        with (open(mirna_out_table, 'r') as expected,
+              open(mirna_output, 'r') as out_file):
             assert out_file.read() == expected.read()
 
-    def test_main_xn_tag_sam_file(self, monkeypatch, tmp_path, xn_tag_sam_file):
+    def test_main_xn_tag_sam_file(self, monkeypatch, tmp_path,
+                                  xn_tag_sam_file):
         """Test main function with feature name in the XN tag."""
         infile, out_table = xn_tag_sam_file
-        output = tmp_path/"mirna_counts_lib"
+        output = tmp_path / "mirna_counts_lib"
 
         monkeypatch.setattr(
             sys, 'argv',
@@ -365,10 +370,11 @@ class TestMain:
         with open(out_table, 'r') as expected, open(output, 'r') as out_file:
             assert out_file.read() == expected.read()
 
-    def test_main_nh_missing_sam_file(self, monkeypatch, tmp_path, nh_missing_sam_file):
+    def test_main_nh_missing_sam_file(self, monkeypatch, tmp_path,
+                                      nh_missing_sam_file):
         """Test main function with some missing NH tag in SAM file."""
         infile, out_table = nh_missing_sam_file
-        output = tmp_path/"mirna_counts_lib"
+        output = tmp_path / "mirna_counts_lib"
 
         monkeypatch.setattr(
             sys, 'argv',
@@ -387,7 +393,7 @@ class TestMain:
     def test_main_seq_len_sam_file(self, monkeypatch, tmp_path, len_sam_file):
         """Test main function with read lenght in output table."""
         infile, out_table = len_sam_file
-        output = tmp_path/"mirna_counts_lib"
+        output = tmp_path / "mirna_counts_lib"
 
         monkeypatch.setattr(
             sys, 'argv',
@@ -408,7 +414,7 @@ class TestMain:
     def test_main_read_sam_file(self, monkeypatch, tmp_path, read_sam_file):
         """Test main function with intersecting read IDs in the output."""
         infile, out_table = read_sam_file
-        output = tmp_path/"mirna_counts_lib"
+        output = tmp_path / "mirna_counts_lib"
 
         monkeypatch.setattr(
             sys, 'argv',
@@ -426,10 +432,11 @@ class TestMain:
         with open(out_table, 'r') as expected, open(output, 'r') as out_file:
             assert out_file.read() == expected.read()
 
-    def test_main_read_len_sam_file(self, monkeypatch, tmp_path, read_len_sam_file):
+    def test_main_read_len_sam_file(self, monkeypatch, tmp_path,
+                                    read_len_sam_file):
         """Test main function with read IDs and feature length im output."""
         infile, out_table = read_len_sam_file
-        output = tmp_path/"mirna_counts_lib"
+        output = tmp_path / "mirna_counts_lib"
 
         monkeypatch.setattr(
             sys, 'argv',
@@ -448,11 +455,11 @@ class TestMain:
         with open(out_table, 'r') as expected, open(output, 'r') as out_file:
             assert out_file.read() == expected.read()
 
-
-    def test_main_uncollpased_sam_file(self, monkeypatch, tmp_path, uncollapsed_sam_file):
+    def test_main_uncollpased_sam_file(self, monkeypatch, tmp_path,
+                                       uncollapsed_sam_file):
         """Test main function with uncollapsed SAM file."""
         infile, out_table = uncollapsed_sam_file
-        output = tmp_path/"mirna_counts_lib"
+        output = tmp_path / "mirna_counts_lib"
 
         monkeypatch.setattr(
             sys, 'argv',
@@ -468,10 +475,11 @@ class TestMain:
         with open(out_table, 'r') as expected, open(output, 'r') as out_file:
             assert out_file.read() == expected.read()
 
-    def test_main_uncollpased_missing_nh_sam_file(self, monkeypatch, tmp_path, uncollapsed_missing_nh_sam_file):
+    def test_main_uncollap_miss_nh_sam_file(self, monkeypatch, tmp_path,
+                                            uncollapsed_missing_nh_sam_file):
         """Test main function with uncollapsed SAM file and missing NH tags."""
         infile, out_table = uncollapsed_missing_nh_sam_file
-        output = tmp_path/"mirna_counts_lib"
+        output = tmp_path / "mirna_counts_lib"
 
         monkeypatch.setattr(
             sys, 'argv',

--- a/scripts/tests/test_oligomap_output_to_sam_nh_filtered.py
+++ b/scripts/tests/test_oligomap_output_to_sam_nh_filtered.py
@@ -3,14 +3,12 @@
 import argparse
 from pathlib import Path
 import sys
-from typing import NamedTuple
 
 import pytest
 
 sys.path.append("../../")
 
-
-from scripts.oligomap_output_to_sam_nh_filtered import(
+from scripts.oligomap_output_to_sam_nh_filtered import (
     eval_aln,
     Fields,
     get_cigar_md,
@@ -45,12 +43,14 @@ def transcriptome_no_nh():
 
     return oligo_in, oligo_out
 
+
 @pytest.fixture
 def single_read():
     """Import path to test file with a single read."""
     oligo_out = Path("files/oligomap_single_read.sam")
-    
+
     return oligo_out
+
 
 @pytest.fixture
 def aln_fields():
@@ -66,18 +66,18 @@ def aln_fields():
     # Alignment with a mismatch in the last position
     field_3 = Fields("read_1", "0", "19", "44278", "255", "19M", '*', '0', '0',
                      "CTACAAAGGGAAGCACTTT", '*', "NM:i:1", "MD:Z:18C")
-        
+
     # Alignment with a mismatch in the middle of the read sequence
     field_4 = Fields("read_1", "0", "19", "50971", "255", "19M", '*', '0', '0',
                      "CTACAAAGGGAAGCACTTT", '*', "NM:i:1", "MD:Z:14C4")
-        
+
     # Alignment with an insertion at read's first position
-    field_5 = Fields("read_2", "16", "19", "7627", "255", "1I22M", '*', '0', '0',
-                     "AAAGCACCTCCAGAGCTTGAAGC", '*', "NM:i:1", "MD:Z:23")
-        
+    field_5 = Fields("read_2", "16", "19", "7627", "255", "1I22M", '*', '0',
+                     '0', "AAAGCACCTCCAGAGCTTGAAGC", '*', "NM:i:1", "MD:Z:23")
+
     # Alignment with an insertion in the middle of the read sequence
-    field_6 = Fields("read_2", "16", "19", "7886", "255", "9M1I12M", '*', '0', '0',
-                     "AAAGCACCTCCAGAGCTTGAAGC", '*', "NM:i:1", "MD:Z:23")
+    field_6 = Fields("read_2", "16", "19", "7886", "255", "9M1I12M", '*', '0',
+                     '0', "AAAGCACCTCCAGAGCTTGAAGC", '*', "NM:i:1", "MD:Z:23")
 
     return [field_1, field_2, field_3, field_4, field_5, field_6]
 
@@ -183,10 +183,10 @@ class TestParseArguments:
         monkeypatch.setattr(
             sys, 'argv',
             ['oligomap_output_to_sam_nh_filtered',
-              str(empty_in),
+             str(empty_in),
              ]
         )
-        
+
         args = parse_arguments().parse_args()
         assert isinstance(args, argparse.Namespace)
 
@@ -201,7 +201,7 @@ class TestParseArguments:
              '-n', '100',
              ]
         )
-        
+
         args = parse_arguments().parse_args()
         assert isinstance(args, argparse.Namespace)
 
@@ -283,7 +283,7 @@ class TestGetCigarMd:
 class TestGetSAMFields():
     """Test 'get_sam_fields()' function."""
 
-    def test_pos_strand_no_err(self,alns, aln_fields):
+    def test_pos_strand_no_err(self, alns, aln_fields):
         """Test perfect alignment in the positive strand."""
         line1 = "read_1 (19 nc) 1...19 19 44377...44395"
         line2 = "19"
@@ -292,7 +292,7 @@ class TestGetSAMFields():
         assert get_sam_fields([line1, line2, line3, alns[0][1],
                               alns[0][2], alns[0][3]]) == aln_fields[0]
 
-    def test_neg_strand_one_err(self,alns, aln_fields):
+    def test_neg_strand_one_err(self, alns, aln_fields):
         """Test alignment with an insertion in the negative strand."""
         line1 = "read_2 (23 nc) 1...23 19 7886...7908"
         line2 = "19"
@@ -308,7 +308,7 @@ class TestEvalAln:
     def test_eval_empty_dict_new_read(self, aln_fields):
         """Test evaluation with a new read and an empty dictionary."""
         d = dict()
-        minerr_nh = {"read_0" : ['0', 1]}
+        minerr_nh = {"read_0": ['0', 1]}
         aln = aln_fields[0]
         nhfilter = None
 
@@ -316,11 +316,11 @@ class TestEvalAln:
 
         assert list(d.keys())[0] == aln.read_name
         assert minerr_nh[aln.read_name] == ['0', 1]
-        
+
     def test_eval_empty_dict_smaller_error(self, aln_fields):
         """Test evaluation with a smaller error and an empty dictionary."""
         d = dict()
-        minerr_nh = {"read_1" : ['1', 1]}
+        minerr_nh = {"read_1": ['1', 1]}
         aln = aln_fields[0]
         nhfilter = None
 
@@ -332,7 +332,7 @@ class TestEvalAln:
     def test_increase_nh_no_filter(self, aln_fields):
         """Test evaluation when increasing NH without a maximum value."""
         d = {"read_1": [aln_fields[1], aln_fields[2]]}
-        minerr_nh = {"read_1" : ['1', 2]}
+        minerr_nh = {"read_1": ['1', 2]}
         aln = aln_fields[3]
         nhfilter = None
 
@@ -344,7 +344,7 @@ class TestEvalAln:
     def test_exceed_nh_filter_2(self, capsys, aln_fields):
         """Test evaluation when exceeding the maximum NH set to 2."""
         d = {"read_1": [aln_fields[1], aln_fields[2]]}
-        minerr_nh = {"read_1" : ['1', 2]}
+        minerr_nh = {"read_1": ['1', 2]}
         aln = aln_fields[3]
         nhfilter = 2
 
@@ -354,11 +354,11 @@ class TestEvalAln:
         assert len(d) == 0
         assert minerr_nh[aln.read_name] == ['1', 3]
         assert captured.err == "Filtered by NH | Read read_1 | Errors = 1\n"
-        
+
     def test_no_exceed_nh_filter_2(self, aln_fields):
         """Test evaluation when increasing NH with maximum value of 2."""
         d = {"read_1": [aln_fields[1]]}
-        minerr_nh = {"read_1" : ['1', 1]}
+        minerr_nh = {"read_1": ['1', 1]}
         aln = aln_fields[2]
         nhfilter = 2
 
@@ -366,13 +366,13 @@ class TestEvalAln:
 
         assert len(d[aln.read_name]) == 2
         assert minerr_nh[aln.read_name] == ['1', 2]
-        
+
     def test_smaller_min_error(self, capsys, aln_fields):
         """Test evaluation when having a smaller minimumm error."""
         d = {"read_1": [aln_fields[1], aln_fields[2]]}
-        minerr_nh = {"read_1" : ['1', 2]}
+        minerr_nh = {"read_1": ['1', 2]}
         aln = aln_fields[0]
-        nhfilter = None 
+        nhfilter = None
 
         eval_aln(nhfilter, d, minerr_nh, aln)
         captured = capsys.readouterr()
@@ -383,13 +383,12 @@ class TestEvalAln:
 
     def test_different_read(self, capsys, tmp_path, aln_fields, single_read):
         """Test evaluation when having to write due to a different read."""
-        output = tmp_path/"oligomap_genome_mappings.sam"
         out_file = single_read
 
         d = {"read_1": [aln_fields[1], aln_fields[2]]}
-        minerr_nh = {"read_1" : ['1', 2]}
+        minerr_nh = {"read_1": ['1', 2]}
         aln = aln_fields[4]
-        nhfilter = None 
+        nhfilter = None
 
         eval_aln(nhfilter, d, minerr_nh, aln)
         captured = capsys.readouterr()
@@ -400,7 +399,7 @@ class TestEvalAln:
 
         with open(out_file, 'r') as expected:
             assert captured.out == expected.read()
-        
+
 
 class TestMain:
     """Test 'main()' function."""
@@ -457,4 +456,3 @@ class TestMain:
 
         with open(out_file, 'r') as expected:
             assert captured.out == expected.read()
-

--- a/scripts/tests/test_primir_quantification.py
+++ b/scripts/tests/test_primir_quantification.py
@@ -56,7 +56,7 @@ def bed_id_files():
     out_table = Path("files/id_primir_quantification")
 
     return in_bed, out_table
-    
+
 
 @pytest.fixture
 def bed_some_extension_files():
@@ -65,6 +65,7 @@ def bed_some_extension_files():
     out_table = Path("files/some_extension_primir_quantification")
 
     return in_bed, out_table
+
 
 @pytest.fixture
 def bed_collapsed_file():
@@ -110,11 +111,11 @@ class TestParseArguments:
         )
         args = parse_arguments().parse_args()
         assert isinstance(args, argparse.Namespace)
-    
+
     def test_too_many_input_files(self, monkeypatch, bed_file):
         """Call with too many input file."""
         in_bed, out_table = bed_file
-        
+
         with pytest.raises(SystemExit) as sysex:
             monkeypatch.setattr(
                 sys, 'argv',
@@ -124,7 +125,7 @@ class TestParseArguments:
             )
             parse_arguments().parse_args()
         assert sysex.value.code == 2
-    
+
     def test_all_input(self, monkeypatch, bed_file):
         """Call with all the options."""
         in_bed, out_table = bed_file
@@ -164,7 +165,8 @@ class TestMain:
         with open(empty_file, 'r') as out_file:
             assert captured.out == out_file.read()
 
-    def test_main_no_extension(self, monkeypatch, capsys, bed_no_extension_files):
+    def test_main_no_extension(self, monkeypatch, capsys,
+                               bed_no_extension_files):
         """Test main function with no extension in features names."""
         in_bed, expected_out = bed_no_extension_files
 
@@ -181,7 +183,8 @@ class TestMain:
         with open(expected_out, 'r') as out_file:
             assert captured.out == out_file.read()
 
-    def test_main_id_extension(self, monkeypatch, capsys, bed_extension_id_files):
+    def test_main_id_extension(self, monkeypatch, capsys,
+                               bed_extension_id_files):
         """Test main function with extension in feature name and read names."""
         in_bed, expected_out = bed_extension_id_files
 
@@ -218,7 +221,8 @@ class TestMain:
         with open(expected_out, 'r') as out_file:
             assert captured.out == out_file.read()
 
-    def test_main_some_extension_file(self, monkeypatch, capsys, bed_some_extension_files):
+    def test_main_some_extension_file(self, monkeypatch, capsys,
+                                      bed_some_extension_files):
         """Test main function with read names."""
         in_bed, expected_out = bed_some_extension_files
 
@@ -255,7 +259,8 @@ class TestMain:
         with open(expected_out, 'r') as out_file:
             assert captured.out == out_file.read()
 
-    def test_main_collpased_file(self, monkeypatch, capsys, bed_collapsed_file):
+    def test_main_collpased_file(self, monkeypatch, capsys,
+                                 bed_collapsed_file):
         """Test main function with collapsed alignments."""
         in_bed, expected_out = bed_collapsed_file
 
@@ -289,4 +294,4 @@ class TestMain:
         captured = capsys.readouterr()
 
         with open(expected_out, 'r') as out_file:
-            assert captured.out == out_file.read()            
+            assert captured.out == out_file.read()


### PR DESCRIPTION
This PR closes #120 .

All the unit test scripts are now passing the `flake8` analysis.

Moreover, the call for ''flake8'' in the CI has been changed. 
For each unit test script,  the error ` E402 module level import not at top of file` appears. Given that the modules are found in the parent directory, to set the path there is required and done after importing `sys`.  Hence, the addition of `--ignore=E402`. 