### PR TITLE
build: set up Black correctly and Snakemake format

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# This file is used to list commits which will be ignored by github to calculate git blame
+# These are commits which modify multiple parts of the codebase, e.g formatting changes
+
+# Format Snakefile with snakefmt
+684d582acdb8af4ae87911dc7eb747411ff30eaa

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,12 +49,8 @@ jobs:
         run: pylint --rcfile=../pylint.cfg ./*.py
 
       - name: black
-        uses: psf/black@stable
-        with:
-          options: "--check --verbose --line-length=79"
-          src: "./scripts"
-          version: "24.1.1"
-
+        working-directory: ./scripts
+        run: black --check --verbose --line-length=79 ./*.py
 
   snakemake-format-graph-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,8 +51,9 @@ jobs:
       - name: black
         uses: psf/black@stable
         with:
-          options: "--check --verbose --line-length=79 --required-version 24.1.1"
+          options: "--check --verbose --line-length=79"
           src: "./scripts"
+          version: "24.1.1"
 
 
   snakemake-format-graph-test:

--- a/environment.dev.yml
+++ b/environment.dev.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - bioconda
 dependencies: 
+  - black>=24.1.1
   - coverage>=7.3.2
   - flake8>=6.1.0
   - flake8-docstrings>=1.7.0

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -107,8 +107,10 @@ rule finish:
             sample=pd.unique(samples_table.index.values),
         ),
         piles_design=expand(
-            PILEUP_DIR / "{condition}" / "check_file_{condition}.txt"
-            if config["lib_dict"] != None
-            else [],
+            (
+                PILEUP_DIR / "{condition}" / "check_file_{condition}.txt"
+                if config["lib_dict"] != None
+                else []
+            ),
             condition=list(config["lib_dict"].keys()),
         ),


### PR DESCRIPTION
This PR:

- corrects the `Black` test in the CI file
- adds `Black` in  `environment.dev.yml` with its current version as the minimum one
- formats the main Snakefile with `snakefmt`
- adds `git-blame-ignore-revs` with the `snakefmt` commit