### PR TITLE
fix: set wildcard correctly

### DIFF
--- a/workflow/rules/pileup.smk
+++ b/workflow/rules/pileup.smk
@@ -139,7 +139,7 @@ rule create_per_library_ascii_pileups:
     params:
         cluster_log=CLUSTER_LOG / "pileups_{sample}.log",
         out_dir=lambda wildcards: expand(
-            PILEUP_DIR / "{sample}", sample=pd.unique(samples_table.index.values)
+            PILEUP_DIR / "{sample}", sample=[wildcards.sample]
         ),
         prefix="{sample}",
     log:


### PR DESCRIPTION
This PR corrects the wildcard setting in the rule creating the ASCII-style pileups per library.