### PR TITLE
build: pin `pysam` version

### DIFF
--- a/environment.dev.yml
+++ b/environment.dev.yml
@@ -11,7 +11,7 @@ dependencies:
   - mypy>=1.15
   - pulp
   - pylint>=3.3.7
-  - pysam>=0.23
+  - pysam=0.23.0
   - pytest>=8.3.5
   - pytest-cov>=6.1.1
   - python>=3.12


### PR DESCRIPTION
This PR closes #160.

When upgrading `pysam`, a higher version on `Cython` was used which clashes with `python >3.13`. The suggested fix ( See https://github.com/pysam-developers/pysam/issues/1350 ) is to pin the `pysam` version to the latest functional version ( `0.23.0` ).
By doing so, no warnings or errors appear on the unit test.

## Summary by Sourcery

Build:
- Pin pysam to exact version 0.23.0 in environment.dev.yml to prevent compatibility issues