### PR TITLE
style: fix python scripts and snakemake files format

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,7 @@
 
 # Format Snakefile with snakefmt
 684d582acdb8af4ae87911dc7eb747411ff30eaa
+6d09e3beccd201881c0811f0d554ac9cf657744e
+
+# Format python scripts with black
+c4275a208778aef34664ce49eaa829f4b17ebef3

--- a/workflow/rules/map.smk
+++ b/workflow/rules/map.smk
@@ -10,7 +10,6 @@ from snakemake.utils import validate
 
 from pathlib import Path
 
-
 ###############################################################################
 ### Configuration validation
 ###############################################################################
@@ -88,12 +87,12 @@ rule start:
         ),
     output:
         reads=INTERMEDIATES_DIR / "{sample}" / "{format}" / "reads.{format}",
-    params:
-        cluster_log=CLUSTER_LOG / "uncompress_zipped_files_{sample}_{format}.log",
     log:
         LOCAL_LOG / "uncompress_zipped_files_{sample}_{format}.log",
     container:
         "docker://ubuntu:noble-20250127"
+    params:
+        cluster_log=CLUSTER_LOG / "uncompress_zipped_files_{sample}_{format}.log",
     shell:
         "(zcat {input.reads} > {output.reads}) &> {log}"
 
@@ -108,16 +107,16 @@ rule fastq_quality_filter:
         reads=INTERMEDIATES_DIR / "{sample}" / "fastq" / "reads.fastq",
     output:
         reads=INTERMEDIATES_DIR / "{sample}" / "fastq" / "filtered_reads.fastq",
+    log:
+        LOCAL_LOG / "fastq_quality_filter_{sample}.log",
+    conda:
+        ENV_DIR / "fastx_toolkit.yaml"
+    container:
+        "docker://quay.io/biocontainers/fastx_toolkit:0.0.14--h503566f_13"
     params:
         cluster_log=CLUSTER_LOG / "fastq_quality_filter_{sample}.log",
         p=config["p_value"],
         q=config["q_value"],
-    log:
-        LOCAL_LOG / "fastq_quality_filter_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/fastx_toolkit:0.0.14--h503566f_13"
-    conda:
-        ENV_DIR / "fastx_toolkit.yaml"
     shell:
         "(fastq_quality_filter \
         -v \
@@ -138,14 +137,14 @@ rule fastq_to_fasta:
         reads=INTERMEDIATES_DIR / "{sample}" / "fastq" / "filtered_reads.fastq",
     output:
         reads=INTERMEDIATES_DIR / "{sample}" / "fastq" / "reads.fa",
-    params:
-        cluster_log=CLUSTER_LOG / "fastq_to_fasta_{sample}.log",
     log:
         LOCAL_LOG / "fastq_to_fasta_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/fastx_toolkit:0.0.14--h503566f_13"
     conda:
         ENV_DIR / "fastx_toolkit.yaml"
+    container:
+        "docker://quay.io/biocontainers/fastx_toolkit:0.0.14--h503566f_13"
+    params:
+        cluster_log=CLUSTER_LOG / "fastq_to_fasta_{sample}.log",
     shell:
         "(fastq_to_fasta -r -n -i {input.reads} > {output.reads}) &> {log}"
 
@@ -163,14 +162,14 @@ rule format_fasta:
         / "reads.fa",
     output:
         reads=INTERMEDIATES_DIR / "{sample}" / "reads_formatted.fasta",
-    params:
-        cluster_log=CLUSTER_LOG / "format_fasta_{sample}.log",
     log:
         LOCAL_LOG / "format_fasta_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/fastx_toolkit:0.0.14--h503566f_13"
     conda:
         ENV_DIR / "fastx_toolkit.yaml"
+    container:
+        "docker://quay.io/biocontainers/fastx_toolkit:0.0.14--h503566f_13"
+    params:
+        cluster_log=CLUSTER_LOG / "format_fasta_{sample}.log",
     shell:
         "(fasta_formatter -w 0 -i {input.reads} > {output.reads}) &> {log}"
 
@@ -185,6 +184,14 @@ rule remove_adapters:
         reads=INTERMEDIATES_DIR / "{sample}" / "reads_formatted.fasta",
     output:
         reads=INTERMEDIATES_DIR / "{sample}" / "reads_trimmed_adapters.fasta",
+    log:
+        LOCAL_LOG / "remove_adapters_{sample}.log",
+    conda:
+        ENV_DIR / "cutadapt.yaml"
+    container:
+        "docker://quay.io/biocontainers/cutadapt:5.0--py39hbcbf7aa_0"
+    resources:
+        threads=8,
     params:
         adapter=lambda wildcards: get_sample("adapter", wildcards.sample).upper(),
         error_rate=config["error_rate"],
@@ -192,14 +199,6 @@ rule remove_adapters:
         overlap=config["overlap"],
         max_n=config["max_n"],
         cluster_log=CLUSTER_LOG / "remove_adapters_{sample}.log",
-    log:
-        LOCAL_LOG / "remove_adapters_{sample}.log",
-    resources:
-        threads=8,
-    container:
-        "docker://quay.io/biocontainers/cutadapt:5.0--py39hbcbf7aa_0"
-    conda:
-        ENV_DIR / "cutadapt.yaml"
     shell:
         "(cutadapt \
         -a {params.adapter} \
@@ -222,14 +221,14 @@ rule collapse_identical_reads:
         reads=INTERMEDIATES_DIR / "{sample}" / "reads_trimmed_adapters.fasta",
     output:
         reads=INTERMEDIATES_DIR / "{sample}" / "reads_collapsed.fasta",
-    params:
-        cluster_log=CLUSTER_LOG / "collapse_identical_reads_{sample}.log",
     log:
         LOCAL_LOG / "collapse_identical_reads_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/fastx_toolkit:0.0.14--h503566f_13"
     conda:
         ENV_DIR / "fastx_toolkit.yaml"
+    container:
+        "docker://quay.io/biocontainers/fastx_toolkit:0.0.14--h503566f_13"
+    params:
+        cluster_log=CLUSTER_LOG / "collapse_identical_reads_{sample}.log",
     shell:
         "(fastx_collapser -i {input.reads} > {output.reads}) &> {log}"
 
@@ -246,18 +245,18 @@ rule map_genome_segemehl:
         genome_index_segemehl=INTERMEDIATES_DIR / "segemehl_genome_index.idx",
     output:
         gmap=INTERMEDIATES_DIR / "{sample}" / "segemehl_genome_mappings.sam",
-    params:
-        cluster_log=CLUSTER_LOG / "map_genome_segemehl_{sample}.log",
     log:
         LOCAL_LOG / "map_genome_segemehl_{sample}.log",
+    conda:
+        ENV_DIR / "segemehl.yaml"
+    container:
+        "docker://quay.io/biocontainers/segemehl:0.3.4--hf7d323f_8"
     resources:
         mem=50,
         time=12,
         threads=8,
-    container:
-        "docker://quay.io/biocontainers/segemehl:0.3.4--hf7d323f_8"
-    conda:
-        ENV_DIR / "segemehl.yaml"
+    params:
+        cluster_log=CLUSTER_LOG / "map_genome_segemehl_{sample}.log",
     shell:
         "(segemehl.x \
         -i {input.genome_index_segemehl} \
@@ -282,18 +281,18 @@ rule map_transcriptome_segemehl:
         / "segemehl_transcriptome_index.idx",
     output:
         tmap=INTERMEDIATES_DIR / "{sample}" / "segemehl_transcriptome_mappings.sam",
-    params:
-        cluster_log=CLUSTER_LOG / "map_transcriptome_segemehl_{sample}.log",
     log:
         LOCAL_LOG / "map_transcriptome_segemehl_{sample}.log",
+    conda:
+        ENV_DIR / "segemehl.yaml"
+    container:
+        "docker://quay.io/biocontainers/segemehl:0.3.4--hf7d323f_8"
     resources:
         mem=10,
         time=12,
         threads=8,
-    container:
-        "docker://quay.io/biocontainers/segemehl:0.3.4--hf7d323f_8"
-    conda:
-        ENV_DIR / "segemehl.yaml"
+    params:
+        cluster_log=CLUSTER_LOG / "map_transcriptome_segemehl_{sample}.log",
     shell:
         "(segemehl.x \
         -i {input.transcriptome_index_segemehl} \
@@ -316,15 +315,15 @@ rule filter_fasta_for_oligomap:
         script=SCRIPTS_DIR / "validation_fasta.py",
     output:
         reads=INTERMEDIATES_DIR / "{sample}" / "reads_filtered_for_oligomap.fasta",
+    log:
+        LOCAL_LOG / "filter_fasta_for_oligomap_{sample}.log",
+    conda:
+        ENV_DIR / "biopython.yaml"
+    container:
+        "docker://quay.io/biocontainers/biopython:1.70--np112py36_1"
     params:
         cluster_log=CLUSTER_LOG / "filter_fasta_for_oligomap_{sample}.log",
         max_length_reads=config["max_length_reads"],
-    log:
-        LOCAL_LOG / "filter_fasta_for_oligomap_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/biopython:1.70--np112py36_1"
-    conda:
-        ENV_DIR / "biopython.yaml"
     shell:
         "(python {input.script} \
         {input.reads} \
@@ -345,18 +344,18 @@ rule map_genome_oligomap:
     output:
         gmap=INTERMEDIATES_DIR / "{sample}" / "oligomap_genome_mappings.oligomap",
         report=INTERMEDIATES_DIR / "{sample}" / "oligomap_genome_report.txt",
-    params:
-        cluster_log=CLUSTER_LOG / "map_genome_oligomap_{sample}.log",
     log:
         LOCAL_LOG / "map_genome_oligomap_{sample}.log",
+    conda:
+        ENV_DIR / "oligomap.yaml"
+    container:
+        "docker://quay.io/biocontainers/oligomap:1.0.1--hdcf5f25_0"
     resources:
         mem=50,
         time=6,
         threads=8,
-    container:
-        "docker://quay.io/biocontainers/oligomap:1.0.1--hdcf5f25_0"
-    conda:
-        ENV_DIR / "oligomap.yaml"
+    params:
+        cluster_log=CLUSTER_LOG / "map_genome_oligomap_{sample}.log",
     shell:
         "(oligomap \
         {input.target} \
@@ -377,15 +376,15 @@ rule sort_genome_oligomap:
         script=SCRIPTS_DIR / "blocksort.sh",
     output:
         sort=INTERMEDIATES_DIR / "{sample}" / "oligomap_genome_sorted.oligomap",
-    params:
-        cluster_log=CLUSTER_LOG / "sort_genome_oligomap_{sample}.log",
     log:
         LOCAL_LOG / "sort_genome_oligomap_{sample}.log",
+    container:
+        "docker://ubuntu:noble-20250127"
     resources:
         threads=8,
         time=6,
-    container:
-        "docker://ubuntu:noble-20250127"
+    params:
+        cluster_log=CLUSTER_LOG / "sort_genome_oligomap_{sample}.log",
     shell:
         "(bash {input.script} \
         {input.tmap} \
@@ -405,18 +404,18 @@ rule convert_genome_to_sam_oligomap:
         script=SCRIPTS_DIR / "oligomap_output_to_sam_nh_filtered.py",
     output:
         gmap=INTERMEDIATES_DIR / "{sample}" / "oligomap_genome_mappings.sam",
-    params:
-        cluster_log=CLUSTER_LOG / "oligomap_genome_to_sam_{sample}.log",
-        nh=config["nh"],
     log:
         LOCAL_LOG / "oligomap_genome_to_sam_{sample}.log",
+    conda:
+        ENV_DIR / "python.yaml"
+    container:
+        "docker://python:3.11.12"
     resources:
         time=1,
         queue=1,
-    container:
-        "docker://python:3.11.12"
-    conda:
-        ENV_DIR / "python.yaml"
+    params:
+        cluster_log=CLUSTER_LOG / "oligomap_genome_to_sam_{sample}.log",
+        nh=config["nh"],
     shell:
         "(python {input.script} \
         {input.sort} \
@@ -436,18 +435,18 @@ rule map_transcriptome_oligomap:
     output:
         tmap=INTERMEDIATES_DIR / "{sample}" / "oligomap_transcriptome_mappings.oligomap",
         report=INTERMEDIATES_DIR / "{sample}" / "oligomap_transcriptome_report.txt",
-    params:
-        cluster_log=CLUSTER_LOG / "map_transcriptome_oligomap_{sample}.log",
     log:
         LOCAL_LOG / "map_transcriptome_oligomap_{sample}.log",
+    conda:
+        ENV_DIR / "oligomap.yaml"
+    container:
+        "docker://quay.io/biocontainers/oligomap:1.0.1--hdcf5f25_0"
     resources:
         mem=10,
         time=6,
         threads=8,
-    container:
-        "docker://quay.io/biocontainers/oligomap:1.0.1--hdcf5f25_0"
-    conda:
-        ENV_DIR / "oligomap.yaml"
+    params:
+        cluster_log=CLUSTER_LOG / "map_transcriptome_oligomap_{sample}.log",
     shell:
         "(oligomap \
         {input.target} \
@@ -469,14 +468,14 @@ rule sort_transcriptome_oligomap:
         script=SCRIPTS_DIR / "blocksort.sh",
     output:
         sort=INTERMEDIATES_DIR / "{sample}" / "oligomap_transcriptome_sorted.oligomap",
-    params:
-        cluster_log=CLUSTER_LOG / "sort_transcriptome_oligomap_{sample}.log",
     log:
         LOCAL_LOG / "sort_transcriptome_oligomap_{sample}.log",
-    resources:
-        threads=8,
     container:
         "docker://ubuntu:noble-20250127"
+    resources:
+        threads=8,
+    params:
+        cluster_log=CLUSTER_LOG / "sort_transcriptome_oligomap_{sample}.log",
     shell:
         "(bash {input.script} \
         {input.tmap} \
@@ -496,15 +495,15 @@ rule convert_transcriptome_to_sam_oligomap:
         script=SCRIPTS_DIR / "oligomap_output_to_sam_nh_filtered.py",
     output:
         tmap=INTERMEDIATES_DIR / "{sample}" / "oligomap_transcriptome_mappings.sam",
+    log:
+        LOCAL_LOG / "oligomap_transcriptome_to_sam_{sample}.log",
+    conda:
+        ENV_DIR / "python.yaml"
+    container:
+        "docker://python:3.11.12"
     params:
         cluster_log=CLUSTER_LOG / "oligomap_transcriptome_to_sam_{sample}.log",
         nh=config["nh"],
-    log:
-        LOCAL_LOG / "oligomap_transcriptome_to_sam_{sample}.log",
-    container:
-        "docker://python:3.11.12"
-    conda:
-        ENV_DIR / "python.yaml"
     shell:
         "(python {input.script} \
         {input.sort} \
@@ -523,12 +522,12 @@ rule merge_genome_maps:
         gmap2=INTERMEDIATES_DIR / "{sample}" / "oligomap_genome_mappings.sam",
     output:
         gmaps=INTERMEDIATES_DIR / "{sample}" / "genome_mappings.sam",
-    params:
-        cluster_log=CLUSTER_LOG / "merge_genome_maps_{sample}.log",
     log:
         LOCAL_LOG / "merge_genome_maps_{sample}.log",
     container:
         "docker://ubuntu:noble-20250127"
+    params:
+        cluster_log=CLUSTER_LOG / "merge_genome_maps_{sample}.log",
     shell:
         "(cat {input.gmap1} {input.gmap2} > {output.gmaps}) &> {log}"
 
@@ -544,12 +543,12 @@ rule merge_transcriptome_maps:
         tmap2=INTERMEDIATES_DIR / "{sample}" / "oligomap_transcriptome_mappings.sam",
     output:
         tmaps=INTERMEDIATES_DIR / "{sample}" / "transcriptome_mappings.sam",
-    params:
-        cluster_log=CLUSTER_LOG / "merge_transcriptome_maps_{sample}.log",
     log:
         LOCAL_LOG / "merge_transcriptome_maps_{sample}.log",
     container:
         "docker://ubuntu:noble-20250127"
+    params:
+        cluster_log=CLUSTER_LOG / "merge_transcriptome_maps_{sample}.log",
     shell:
         "(cat {input.tmap1} {input.tmap2} > {output.tmaps}) &> {log}"
 
@@ -565,15 +564,15 @@ rule filter_genome_by_nh:
         script=SCRIPTS_DIR / "nh_filter.py",
     output:
         gmaps=INTERMEDIATES_DIR / "{sample}" / "genome_mappings_filtered_nh.sam",
+    log:
+        LOCAL_LOG / "filter_genome_by_nh_{sample}.log",
+    conda:
+        ENV_DIR / "pysam.yaml"
+    container:
+        "docker://quay.io/biocontainers/pysam:0.23.0--py39hdd5828d_0"
     params:
         cluster_log=CLUSTER_LOG / "filter_genome_by_nh_{sample}.log",
         nh=config["nh"],
-    log:
-        LOCAL_LOG / "filter_genome_by_nh_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/pysam:0.23.0--py39hdd5828d_0"
-    conda:
-        ENV_DIR / "pysam.yaml"
     shell:
         "(python {input.script} \
         {input.gmaps} \
@@ -593,15 +592,15 @@ rule filter_transcriptome_by_nh:
         script=SCRIPTS_DIR / "nh_filter.py",
     output:
         tmaps=INTERMEDIATES_DIR / "{sample}" / "transcriptome_mappings_filtered_nh.sam",
+    log:
+        LOCAL_LOG / "filter_transcriptome_by_nh_{sample}.log",
+    conda:
+        ENV_DIR / "pysam.yaml"
+    container:
+        "docker://quay.io/biocontainers/pysam:0.23.0--py39hdd5828d_0"
     params:
         cluster_log=CLUSTER_LOG / "filter_transcriptome_by_nh_{sample}.log",
         nh=config["nh"],
-    log:
-        LOCAL_LOG / "filter_transcriptome_by_nh_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/pysam:0.23.0--py39hdd5828d_0"
-    conda:
-        ENV_DIR / "pysam.yaml"
     shell:
         "(python {input.script} \
         {input.tmaps} \
@@ -620,14 +619,14 @@ rule remove_header_genome_mappings:
         gmap=INTERMEDIATES_DIR / "{sample}" / "genome_mappings_filtered_nh.sam",
     output:
         gmap=INTERMEDIATES_DIR / "{sample}" / "genome_mappings_no_header.sam",
-    params:
-        cluster_log=CLUSTER_LOG / "remove_header_genome_mappings_{sample}.log",
     log:
         LOCAL_LOG / "remove_header_genome_mappings_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
     conda:
         ENV_DIR / "samtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
+    params:
+        cluster_log=CLUSTER_LOG / "remove_header_genome_mappings_{sample}.log",
     shell:
         "samtools view {input.gmap} > {output.gmap}"
 
@@ -642,14 +641,14 @@ rule remove_header_transcriptome_mappings:
         tmap=INTERMEDIATES_DIR / "{sample}" / "transcriptome_mappings_filtered_nh.sam",
     output:
         tmap=INTERMEDIATES_DIR / "{sample}" / "transcriptome_mappings_no_header.sam",
-    params:
-        cluster_log=CLUSTER_LOG / "remove_header_transcriptome_mappings_{sample}.log",
     log:
         LOCAL_LOG / "remove_header_transcriptome_mappings_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
     conda:
         ENV_DIR / "samtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
+    params:
+        cluster_log=CLUSTER_LOG / "remove_header_transcriptome_mappings_{sample}.log",
     shell:
         "samtools view {input.tmap} > {output.tmap}"
 
@@ -666,14 +665,14 @@ rule transcriptome_to_genome_maps:
         exons=INTERMEDIATES_DIR / "exons.bed",
     output:
         genout=INTERMEDIATES_DIR / "{sample}" / "transcriptome_mappings_to_genome.sam",
-    params:
-        cluster_log=CLUSTER_LOG / "transcriptome_to_genome_maps_{sample}.log",
     log:
         LOCAL_LOG / "transcriptome_to_genome_maps_{sample}.log",
-    container:
-        "docker://perl:5.40.2"
     conda:
         ENV_DIR / "perl.yaml"
+    container:
+        "docker://perl:5.40.2"
+    params:
+        cluster_log=CLUSTER_LOG / "transcriptome_to_genome_maps_{sample}.log",
     shell:
         "(perl {input.script} \
         --in {input.tmap} \
@@ -693,12 +692,12 @@ rule merge_all_maps:
         gmap2=INTERMEDIATES_DIR / "{sample}" / "genome_mappings_no_header.sam",
     output:
         catmaps=INTERMEDIATES_DIR / "{sample}" / "mappings_all_no_header.sam",
-    params:
-        cluster_log=CLUSTER_LOG / "merge_all_mappings_{sample}.log",
     log:
         LOCAL_LOG / "merge_all_mappings_{sample}.log",
     container:
         "docker://ubuntu:noble-20250127"
+    params:
+        cluster_log=CLUSTER_LOG / "merge_all_mappings_{sample}.log",
     shell:
         "(cat {input.gmap1} {input.gmap2} > {output.catmaps}) &> {log}"
 
@@ -714,12 +713,12 @@ rule add_header_all_maps:
         catmaps=INTERMEDIATES_DIR / "{sample}" / "mappings_all_no_header.sam",
     output:
         concatenate=INTERMEDIATES_DIR / "{sample}" / "mappings_all.sam",
-    params:
-        cluster_log=CLUSTER_LOG / "add_header_{sample}.log",
     log:
         LOCAL_LOG / "add_header_{sample}.log",
     container:
         "docker://ubuntu:noble-20250127"
+    params:
+        cluster_log=CLUSTER_LOG / "add_header_{sample}.log",
     shell:
         "(cat {input.header} {input.catmaps} > {output.concatenate}) &> {log}"
 
@@ -734,14 +733,14 @@ rule sort_maps_by_id:
         concatenate=INTERMEDIATES_DIR / "{sample}" / "mappings_all.sam",
     output:
         sort=INTERMEDIATES_DIR / "{sample}" / "mappings_all_sorted_by_id.sam",
-    params:
-        cluster_log=CLUSTER_LOG / "sort_maps_by_id_{sample}.log",
     log:
         LOCAL_LOG / "sort_maps_by_id_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
     conda:
         ENV_DIR / "samtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
+    params:
+        cluster_log=CLUSTER_LOG / "sort_maps_by_id_{sample}.log",
     shell:
         "(samtools sort -n -o {output.sort} {input.concatenate}) &> {log}"
 
@@ -757,17 +756,17 @@ rule remove_inferiors:
         script=SCRIPTS_DIR / "sam_remove_duplicates_inferior_alignments_multimappers.pl",
     output:
         remove_inf=INTERMEDIATES_DIR / "{sample}" / "mappings_all_removed_inferiors.sam",
-    params:
-        cluster_log=CLUSTER_LOG / "remove_inferiors_{sample}.log",
     log:
         LOCAL_LOG / "remove_inferiors_{sample}.log",
+    conda:
+        ENV_DIR / "perl.yaml"
+    container:
+        "docker://perl:5.40.2"
     resources:
         mem=15,
         threads=4,
-    container:
-        "docker://perl:5.40.2"
-    conda:
-        ENV_DIR / "perl.yaml"
+    params:
+        cluster_log=CLUSTER_LOG / "remove_inferiors_{sample}.log",
     shell:
         "(perl {input.script} \
         --print-header \
@@ -788,17 +787,17 @@ rule filter_by_indels:
         script=SCRIPTS_DIR / "filter_multimappers.py",
     output:
         sam=INTERMEDIATES_DIR / "{sample}" / "alignments_all.sam",
-    params:
-        cluster_log=CLUSTER_LOG / "remove_multimappers_{sample}.log",
     log:
         LOCAL_LOG / "remove_multimappers_{sample}.log",
+    conda:
+        ENV_DIR / "pysam.yaml"
+    container:
+        "docker://quay.io/biocontainers/pysam:0.23.0--py39hdd5828d_0"
     resources:
         mem=15,
         threads=4,
-    container:
-        "docker://quay.io/biocontainers/pysam:0.23.0--py39hdd5828d_0"
-    conda:
-        ENV_DIR / "pysam.yaml"
+    params:
+        cluster_log=CLUSTER_LOG / "remove_multimappers_{sample}.log",
     shell:
         "(python {input.script} \
         {input.sam} \
@@ -817,14 +816,14 @@ rule convert_all_alns_sam_to_bam:
         maps=INTERMEDIATES_DIR / "{sample}" / "alignments_all.sam",
     output:
         maps=INTERMEDIATES_DIR / "{sample}" / "alignments_all.bam",
-    params:
-        cluster_log=CLUSTER_LOG / "convert_all_alns_sam_to_bam_{sample}.log",
     log:
         LOCAL_LOG / "convert_all_alns_sam_to_bam_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
     conda:
         ENV_DIR / "samtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
+    params:
+        cluster_log=CLUSTER_LOG / "convert_all_alns_sam_to_bam_{sample}.log",
     shell:
         "(samtools view -b {input.maps} > {output.maps}) &> {log}"
 
@@ -839,14 +838,14 @@ rule sort_all_alns_bam_by_position:
         maps=INTERMEDIATES_DIR / "{sample}" / "alignments_all.bam",
     output:
         maps=INTERMEDIATES_DIR / "{sample}" / "alignments_all_sorted_{sample}.bam",
-    params:
-        cluster_log=CLUSTER_LOG / "sort_all_alns_bam_by_position_{sample}.log",
     log:
         LOCAL_LOG / "sort_all_alns_bam_by_position_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
     conda:
         ENV_DIR / "samtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
+    params:
+        cluster_log=CLUSTER_LOG / "sort_all_alns_bam_by_position_{sample}.log",
     shell:
         "(samtools sort {input.maps} > {output.maps}) &> {log}"
 
@@ -861,13 +860,13 @@ rule index_all_alns_bam:
         maps=INTERMEDIATES_DIR / "{sample}" / "alignments_all_sorted.bam",
     output:
         maps=INTERMEDIATES_DIR / "{sample}" / "alignments_all_sorted.bam.bai",
-    params:
-        cluster_log=CLUSTER_LOG / "index_all_alns_bam_{sample}.log",
     log:
         LOCAL_LOG / "index_all_alns_bam_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
     conda:
         ENV_DIR / "samtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
+    params:
+        cluster_log=CLUSTER_LOG / "index_all_alns_bam_{sample}.log",
     shell:
         "(samtools index -b {input.maps} > {output.maps}) &> {log}"

--- a/workflow/rules/pileup.smk
+++ b/workflow/rules/pileup.smk
@@ -10,7 +10,6 @@ from snakemake.utils import validate
 
 from pathlib import Path
 
-
 ###############################################################################
 ### Configuration validation
 ###############################################################################
@@ -87,12 +86,12 @@ if config["bed_file"] == "":
     rule create_empty_bed:
         output:
             create_empty_bed_file(config, INTERMEDIATES_DIR),
-        params:
-            cluster_log=CLUSTER_LOG / "create_empty_bed.log",
         log:
             LOCAL_LOG / "create_empty_bed.log",
         container:
             "docker://ubuntu:lunar-20221207"
+        params:
+            cluster_log=CLUSTER_LOG / "create_empty_bed.log",
         shell:
             "(touch {output})"
 
@@ -107,14 +106,14 @@ rule compress_reference_genome:
         genome=INTERMEDIATES_DIR / "genome_processed.fa",
     output:
         genome=INTERMEDIATES_DIR / "genome_processed.fa.bz",
-    params:
-        cluster_log=CLUSTER_LOG / "compress_reference_genome.log",
     log:
         LOCAL_LOG / "compress_reference_genome.log",
-    container:
-        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
     conda:
         ENV_DIR / "samtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
+    params:
+        cluster_log=CLUSTER_LOG / "compress_reference_genome.log",
     shell:
         "(bgzip < {input.genome} > {output.genome}) &> {log}"
 
@@ -138,18 +137,18 @@ rule create_per_library_ascii_pileups:
         script=SCRIPTS_DIR / "ascii_alignment_pileup.R",
     output:
         piles=PILEUP_DIR / "{sample}" / "check_file.txt",
+    log:
+        LOCAL_LOG / "pileups_{sample}.log",
+    conda:
+        ENV_DIR / "r.yaml"
+    container:
+        "docker://zavolab/ascii-alignment-pileup:1.1.1"
     params:
         cluster_log=CLUSTER_LOG / "pileups_{sample}.log",
         out_dir=lambda wildcards: expand(
             PILEUP_DIR / "{sample}", sample=[wildcards.sample]
         ),
         prefix="{sample}",
-    log:
-        LOCAL_LOG / "pileups_{sample}.log",
-    container:
-        "docker://zavolab/ascii-alignment-pileup:1.1.1"
-    conda:
-        ENV_DIR / "r.yaml"
     shell:
         "(touch {output.piles} && Rscript {input.script} \
         --verbose \
@@ -187,18 +186,18 @@ rule create_per_run_ascii_pileups:
         script=SCRIPTS_DIR / "ascii_alignment_pileup.R",
     output:
         piles=PILEUP_DIR / "all/check_file.txt",
+    log:
+        LOCAL_LOG / "pileups_whole_run.log",
+    conda:
+        ENV_DIR / "r.yaml"
+    container:
+        "docker://zavolab/ascii-alignment-pileup:1.1.1"
+    resources:
+        mem=16,
     params:
         cluster_log=CLUSTER_LOG / "pileups_whole_run.log",
         out_dir=PILEUP_DIR / "all",
         prefix="all_samples",
-    resources:
-        mem=16,
-    log:
-        LOCAL_LOG / "pileups_whole_run.log",
-    container:
-        "docker://zavolab/ascii-alignment-pileup:1.1.1"
-    conda:
-        ENV_DIR / "r.yaml"
     shell:
         "(touch {output.piles} && Rscript {input.script} \
         --verbose \
@@ -238,18 +237,18 @@ if config["lib_dict"] != None:
             script=SCRIPTS_DIR / "ascii_alignment_pileup.R",
         output:
             piles=PILEUP_DIR / "{condition}" / "check_file_{condition}.txt",
+        log:
+            LOCAL_LOG / "pileups_condition_{condition}.log",
+        conda:
+            ENV_DIR / "r.yaml"
+        container:
+            "docker://zavolab/ascii-alignment-pileup:1.1.1"
         params:
             cluster_log=CLUSTER_LOG / "pileups_condition_{condition}.log",
             out_dir=lambda wildcards: expand(
                 PILEUP_DIR / "{condition}", condition=wildcards.condition
             ),
             prefix="{condition}",
-        log:
-            LOCAL_LOG / "pileups_condition_{condition}.log",
-        container:
-            "docker://zavolab/ascii-alignment-pileup:1.1.1"
-        conda:
-            ENV_DIR / "r.yaml"
         shell:
             "(touch {output.piles} && Rscript {input.script} \
             --verbose \

--- a/workflow/rules/prepare.smk
+++ b/workflow/rules/prepare.smk
@@ -11,7 +11,6 @@ from snakemake.utils import validate
 
 from pathlib import Path
 
-
 ###############################################################################
 ### Configuration validation
 ###############################################################################
@@ -75,12 +74,12 @@ rule trim_genome_seq_ids:
         script=SCRIPTS_DIR / "trim_id_fasta.sh",
     output:
         genome=INTERMEDIATES_DIR / "genome_processed.fa",
-    params:
-        cluster_log=CLUSTER_LOG / "genome_process.log",
     log:
         LOCAL_LOG / "genome_process.log",
     container:
         "docker://ubuntu:noble-20250127"
+    params:
+        cluster_log=CLUSTER_LOG / "genome_process.log",
     shell:
         "(zcat {input.genome} | {input.script} > {output.genome}) &> {log}"
 
@@ -96,14 +95,14 @@ rule extract_transcriptome_seqs:
         gtf=config["gtf_file"],
     output:
         fasta=INTERMEDIATES_DIR / "transcriptome.fa",
-    params:
-        cluster_log=CLUSTER_LOG / "extract_transcriptome_seqs.log",
     log:
         LOCAL_LOG / "extract_transcriptome_seqs.log",
-    container:
-        "docker://quay.io/biocontainers/cufflinks:2.2.1--py27_2"
     conda:
         ENV_DIR / "cufflinks.yaml"
+    container:
+        "docker://quay.io/biocontainers/cufflinks:2.2.1--py27_2"
+    params:
+        cluster_log=CLUSTER_LOG / "extract_transcriptome_seqs.log",
     shell:
         "(zcat {input.gtf} | gffread -w {output.fasta} -g {input.genome}) &> {log}"
 
@@ -119,12 +118,12 @@ rule trim_transcriptome_seq_ids:
         script=SCRIPTS_DIR / "trim_id_fasta.sh",
     output:
         fasta=INTERMEDIATES_DIR / "transcriptome_trimmed_id.fa",
-    params:
-        cluster_log=CLUSTER_LOG / "trim_transcriptome.log",
     log:
         LOCAL_LOG / "trim_transcriptome.log",
     container:
         "docker://ubuntu:noble-20250127"
+    params:
+        cluster_log=CLUSTER_LOG / "trim_transcriptome.log",
     shell:
         "(cat {input.fasta} | {input.script} > {output.fasta}) &> {log}"
 
@@ -139,18 +138,18 @@ rule generate_segemehl_index_transcriptome:
         fasta=INTERMEDIATES_DIR / "transcriptome_trimmed_id.fa",
     output:
         idx=INTERMEDIATES_DIR / "segemehl_transcriptome_index.idx",
-    params:
-        cluster_log=CLUSTER_LOG / "generate_segemehl_index_transcriptome.log",
     log:
         LOCAL_LOG / "generate_segemehl_index_transcriptome.log",
+    conda:
+        ENV_DIR / "segemehl.yaml"
+    container:
+        "docker://quay.io/biocontainers/segemehl:0.3.4--hf7d323f_8"
     resources:
         mem=10,
         threads=8,
         time=6,
-    container:
-        "docker://quay.io/biocontainers/segemehl:0.3.4--hf7d323f_8"
-    conda:
-        ENV_DIR / "segemehl.yaml"
+    params:
+        cluster_log=CLUSTER_LOG / "generate_segemehl_index_transcriptome.log",
     shell:
         "(segemehl.x -x {output.idx} -d {input.fasta}) &> {log}"
 
@@ -165,18 +164,18 @@ rule generate_segemehl_index_genome:
         genome=INTERMEDIATES_DIR / "genome_processed.fa",
     output:
         idx=INTERMEDIATES_DIR / "segemehl_genome_index.idx",
-    params:
-        cluster_log=CLUSTER_LOG / "generate_segemehl_index_genome.log",
     log:
         LOCAL_LOG / "generate_segemehl_index_genome.log",
+    conda:
+        ENV_DIR / "segemehl.yaml"
+    container:
+        "docker://quay.io/biocontainers/segemehl:0.3.4--hf7d323f_8"
     resources:
         mem=60,
         threads=8,
         time=6,
-    container:
-        "docker://quay.io/biocontainers/segemehl:0.3.4--hf7d323f_8"
-    conda:
-        ENV_DIR / "segemehl.yaml"
+    params:
+        cluster_log=CLUSTER_LOG / "generate_segemehl_index_genome.log",
     shell:
         "(segemehl.x -x {output.idx} -d {input.genome}) &> {log}"
 
@@ -192,12 +191,12 @@ rule get_exons_gtf:
         script=SCRIPTS_DIR / "get_lines_w_pattern.sh",
     output:
         exons=INTERMEDIATES_DIR / "exons.gtf",
-    params:
-        cluster_log=CLUSTER_LOG / "get_exons_gtf.log",
     log:
         LOCAL_LOG / "get_exons_gtf.log",
     container:
         "docker://ubuntu:noble-20250127"
+    params:
+        cluster_log=CLUSTER_LOG / "get_exons_gtf.log",
     shell:
         "(bash \
         {input.script} \
@@ -219,14 +218,14 @@ rule convert_exons_gtf_to_bed:
         script=SCRIPTS_DIR / "gtf_exons_bed.1.1.2.R",
     output:
         exons=INTERMEDIATES_DIR / "exons.bed",
-    params:
-        cluster_log=CLUSTER_LOG / "exons_gtf_to_bed.log",
     log:
         LOCAL_LOG / "exons_gtf_to_bed.log",
-    container:
-        "docker://zavolab/r-zavolab:3.5.1"
     conda:
         ENV_DIR / "r.yaml"
+    container:
+        "docker://zavolab/r-zavolab:3.5.1"
+    params:
+        cluster_log=CLUSTER_LOG / "exons_gtf_to_bed.log",
     shell:
         "(Rscript \
         {input.script} \
@@ -245,14 +244,14 @@ rule create_genome_header:
         genome=INTERMEDIATES_DIR / "genome_processed.fa",
     output:
         header=INTERMEDIATES_DIR / "genome_header.sam",
-    params:
-        cluster_log=CLUSTER_LOG / "create_genome_header.log",
     log:
         LOCAL_LOG / "create_genome_header.log",
-    container:
-        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
     conda:
         ENV_DIR / "samtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
+    params:
+        cluster_log=CLUSTER_LOG / "create_genome_header.log",
     shell:
         "(samtools dict -o {output.header} --uri=NA {input.genome}) &> {log}"
 
@@ -269,16 +268,16 @@ rule map_chr_names:
         map_chr=config["map_chr_file"],
     output:
         gff=INTERMEDIATES_DIR / "mirna_annotations.gff3",
+    log:
+        LOCAL_LOG / "map_chr_names.log",
+    conda:
+        ENV_DIR / "perl.yaml"
+    container:
+        "docker://perl:5.40.2"
     params:
         cluster_log=CLUSTER_LOG / "map_chr_names.log",
         column="1",
         delimiter="TAB",
-    log:
-        LOCAL_LOG / "map_chr_names.log",
-    container:
-        "docker://perl:5.40.2"
-    conda:
-        ENV_DIR / "perl.yaml"
     shell:
         "(perl {input.script} \
         {input.anno} \
@@ -299,14 +298,14 @@ rule create_index_genome_fasta:
         genome=INTERMEDIATES_DIR / "genome_processed.fa",
     output:
         genome=INTERMEDIATES_DIR / "genome_processed.fa.fai",
-    params:
-        cluster_log=CLUSTER_LOG / "create_index_genome_fasta.log",
     log:
         LOCAL_LOG / "create_index_genome_fasta.log",
-    container:
-        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
     conda:
         ENV_DIR / "samtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
+    params:
+        cluster_log=CLUSTER_LOG / "create_index_genome_fasta.log",
     shell:
         "(samtools faidx {input.genome}) &> {log}"
 
@@ -321,12 +320,12 @@ rule extract_chr_len:
         genome=INTERMEDIATES_DIR / "genome_processed.fa.fai",
     output:
         chrsize=INTERMEDIATES_DIR / "chr_size.tsv",
-    params:
-        cluster_log=CLUSTER_LOG / "extract_chr_len.log",
     log:
         LOCAL_LOG / "extract_chr_len.log",
     container:
         "docker://ubuntu:noble-20250127"
+    params:
+        cluster_log=CLUSTER_LOG / "extract_chr_len.log",
     shell:
         "(cut -f1,2 {input.genome} > {output.chrsize}) &> {log}"
 
@@ -350,16 +349,16 @@ rule extend_mirs_annotations:
             INTERMEDIATES_DIR / "extended_primir_annotation_{extension}_nt.gff3",
             extension=config["extension"],
         ),
+    log:
+        LOCAL_LOG / "extend_mirs_annotations.log",
+    conda:
+        ENV_DIR / "gffutils.yaml"
+    container:
+        "docker://quay.io/biocontainers/gffutils:0.13--pyh7cba7a3_0"
     params:
         cluster_log=CLUSTER_LOG / "extend_mirs_annotations.log",
         out_dir=INTERMEDIATES_DIR,
         extension=config["extension"],
-    log:
-        LOCAL_LOG / "extend_mirs_annotations.log",
-    container:
-        "docker://quay.io/biocontainers/gffutils:0.13--pyh7cba7a3_0"
-    conda:
-        ENV_DIR / "gffutils.yaml"
     shell:
         "(python {input.script} \
         {input.gff3} \

--- a/workflow/rules/quantify.smk
+++ b/workflow/rules/quantify.smk
@@ -10,7 +10,6 @@ from snakemake.utils import validate
 
 from pathlib import Path
 
-
 ###############################################################################
 ### Configuration validation
 ###############################################################################
@@ -104,14 +103,14 @@ rule intersect_extended_primir:
         intersect=INTERMEDIATES_DIR
         / "{sample}"
         / "intersected_extended_primir.intersect",
-    params:
-        cluster_log=CLUSTER_LOG / "intersect_extended_primir_{sample}.log",
     log:
         LOCAL_LOG / "intersect_extended_primir_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/bedtools:2.31.1--h13024bc_3"
     conda:
         ENV_DIR / "bedtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/bedtools:2.31.1--h13024bc_3"
+    params:
+        cluster_log=CLUSTER_LOG / "intersect_extended_primir_{sample}.log",
     shell:
         "(bedtools intersect \
         -wo \
@@ -136,14 +135,14 @@ rule filter_sam_by_intersecting_primir:
         / "intersected_extended_primir.intersect",
     output:
         sam=OUT_DIR / "{sample}" / "alignments_intersecting_primir.sam",
-    params:
-        cluster_log=CLUSTER_LOG / "filter_sam_by_intersecting_primir_{sample}.log",
     log:
         LOCAL_LOG / "filter_sam_by_intersecting_primir_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
     conda:
         ENV_DIR / "samtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
+    params:
+        cluster_log=CLUSTER_LOG / "filter_sam_by_intersecting_primir_{sample}.log",
     shell:
         "((samtools view \
         -H {input.alignments}; \
@@ -163,14 +162,14 @@ rule convert_intersecting_primir_sam_to_bam:
         maps=OUT_DIR / "{sample}" / "alignments_intersecting_primir.sam",
     output:
         maps=INTERMEDIATES_DIR / "{sample}" / "alignments_intersecting_primir.bam",
-    params:
-        cluster_log=CLUSTER_LOG / "convert_intersecting_primir_sam_to_bam_{sample}.log",
     log:
         LOCAL_LOG / "convert_intersecting_primir_sam_to_bam_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
     conda:
         ENV_DIR / "samtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
+    params:
+        cluster_log=CLUSTER_LOG / "convert_intersecting_primir_sam_to_bam_{sample}.log",
     shell:
         "(samtools view -b {input.maps} > {output.maps}) &> {log}"
 
@@ -187,15 +186,15 @@ rule sort_intersecting_primir_bam_by_position:
         maps=INTERMEDIATES_DIR
         / "{sample}"
         / "alignments_intersecting_primir_sorted.bam",
+    log:
+        LOCAL_LOG / "sort_intersecting_primir_bam_by_position_{sample}.log",
+    conda:
+        ENV_DIR / "samtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
     params:
         cluster_log=CLUSTER_LOG
         / "sort_intersecting_primir_bam_by_position_{sample}.log",
-    log:
-        LOCAL_LOG / "sort_intersecting_primir_bam_by_position_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
-    conda:
-        ENV_DIR / "samtools.yaml"
     shell:
         "(samtools sort -n {input.maps} > {output.maps}) &> {log}"
 
@@ -214,14 +213,14 @@ rule index_intersecting_primir_bam:
         maps=INTERMEDIATES_DIR
         / "{sample}"
         / "alignments_intersecting_primir_sorted.bam.bai",
-    params:
-        cluster_log=CLUSTER_LOG / "index_intersecting_primir_bam_{sample}.log",
     log:
         LOCAL_LOG / "index_intersecting_primir_bam_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
     conda:
         ENV_DIR / "samtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
+    params:
+        cluster_log=CLUSTER_LOG / "index_intersecting_primir_bam_{sample}.log",
     shell:
         "(samtools index -b {input.maps} > {output.maps}) &> {log}"
 
@@ -244,14 +243,14 @@ rule intersect_extended_mirna:
         intersect=INTERMEDIATES_DIR
         / "{sample}"
         / "intersected_extended_mirna.intersect",
-    params:
-        cluster_log=CLUSTER_LOG / "intersect_extended_mirna_{sample}.log",
     log:
         LOCAL_LOG / "intersect_extended_mirna_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/bedtools:2.31.1--h13024bc_3"
     conda:
         ENV_DIR / "bedtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/bedtools:2.31.1--h13024bc_3"
+    params:
+        cluster_log=CLUSTER_LOG / "intersect_extended_mirna_{sample}.log",
     shell:
         "(bedtools intersect \
         -wo \
@@ -276,14 +275,14 @@ rule filter_sam_by_intersecting_mirna:
         / "intersected_extended_mirna.intersect",
     output:
         sam=OUT_DIR / "{sample}" / "alignments_intersecting_mirna.sam",
-    params:
-        cluster_log=CLUSTER_LOG / "filter_sam_by_intersecting_mirna_{sample}.log",
     log:
         LOCAL_LOG / "filter_sam_by_intersecting_mirna_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
     conda:
         ENV_DIR / "samtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
+    params:
+        cluster_log=CLUSTER_LOG / "filter_sam_by_intersecting_mirna_{sample}.log",
     shell:
         "((samtools view \
         -H {input.alignments}; \
@@ -307,15 +306,15 @@ rule add_intersecting_mirna_tag:
         script=SCRIPTS_DIR / "annotate_sam_with_intersecting_features.py",
     output:
         sam=INTERMEDIATES_DIR / "{sample}" / "alignments_intersecting_mirna_tag.sam",
+    log:
+        LOCAL_LOG / "add_intersecting_mirna_tag_{sample}.log",
+    conda:
+        ENV_DIR / "pysam.yaml"
+    container:
+        "docker://quay.io/biocontainers/pysam:0.23.0--py39hdd5828d_0"
     params:
         extension=config["extension"],
         cluster_log=CLUSTER_LOG / "add_intersecting_mirna_tag_{sample}.log",
-    log:
-        LOCAL_LOG / "add_intersecting_mirna_tag_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/pysam:0.23.0--py39hdd5828d_0"
-    conda:
-        ENV_DIR / "pysam.yaml"
     shell:
         "(python {input.script} \
         --intersect {input.intersect} \
@@ -337,14 +336,14 @@ rule sort_intersecting_mirna_by_feat_tag:
         sam=INTERMEDIATES_DIR
         / "{sample}"
         / "alignments_intersecting_mirna_sorted_tag.sam",
-    params:
-        cluster_log=CLUSTER_LOG / "sort_intersecting_mirna_by_feat_tag_{sample}.log",
     log:
         LOCAL_LOG / "sort_intersecting_mirna_by_feat_tag_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
     conda:
         ENV_DIR / "samtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
+    params:
+        cluster_log=CLUSTER_LOG / "sort_intersecting_mirna_by_feat_tag_{sample}.log",
     shell:
         "(samtools sort -t YW -O SAM {input.sam} > {output.sam}) &> {log}"
 
@@ -362,17 +361,17 @@ rule quantify_mirna:
         script=SCRIPTS_DIR / "mirna_quantification.py",
     output:
         table=INTERMEDIATES_DIR / "TABLES" / "mirna_counts_{sample}",
+    log:
+        LOCAL_LOG / "quantify_mirna_{sample}.log",
+    conda:
+        ENV_DIR / "pysam.yaml"
+    container:
+        "docker://quay.io/biocontainers/pysam:0.23.0--py39hdd5828d_0"
     params:
         cluster_log=CLUSTER_LOG / "quantify_mirna_{sample}.log",
         mir_list=config["mir_list"],
         library="{sample}",
         out_dir=INTERMEDIATES_DIR / "TABLES",
-    log:
-        LOCAL_LOG / "quantify_mirna_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/pysam:0.23.0--py39hdd5828d_0"
-    conda:
-        ENV_DIR / "pysam.yaml"
     shell:
         "(python \
         {input.script} \
@@ -398,14 +397,14 @@ rule quantify_primir:
         script=SCRIPTS_DIR / "primir_quantification.py",
     output:
         table=INTERMEDIATES_DIR / "TABLES" / "pri-mir_counts_{sample}",
-    params:
-        cluster_log=CLUSTER_LOG / "quantify_primir_{sample}.log",
     log:
         LOCAL_LOG / "quantify_primir_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/pysam:0.23.0--py39hdd5828d_0"
     conda:
         ENV_DIR / "pysam.yaml"
+    container:
+        "docker://quay.io/biocontainers/pysam:0.23.0--py39hdd5828d_0"
+    params:
+        cluster_log=CLUSTER_LOG / "quantify_primir_{sample}.log",
     shell:
         "(python \
         {input.script} \
@@ -431,16 +430,16 @@ rule merge_tables:
         script=SCRIPTS_DIR / "merge_tables.R",
     output:
         table=OUT_DIR / "TABLES" / "all_{mirna}_counts.tab",
+    log:
+        LOCAL_LOG / "merge_tables_{mirna}.log",
+    conda:
+        ENV_DIR / "r.yaml"
+    container:
+        "docker://zavolab/r-tidyverse:3.5.3"
     params:
         cluster_log=CLUSTER_LOG / "merge_tables_{mirna}.log",
         prefix="{mirna}_counts_",
         input_dir=INTERMEDIATES_DIR / "TABLES",
-    log:
-        LOCAL_LOG / "merge_tables_{mirna}.log",
-    container:
-        "docker://zavolab/r-tidyverse:3.5.3"
-    conda:
-        ENV_DIR / "r.yaml"
     shell:
         "(Rscript \
         {input.script} \
@@ -464,14 +463,14 @@ rule uncollapse_reads:
         maps=INTERMEDIATES_DIR
         / "{sample}"
         / "alignments_intersecting_mirna_uncollapsed.sam",
-    params:
-        cluster_log=CLUSTER_LOG / "uncollapse_reads_{sample}.log",
     log:
         LOCAL_LOG / "uncollapse_reads_{sample}.log",
-    container:
-        "docker://perl:5.40.2"
     conda:
         ENV_DIR / "perl.yaml"
+    container:
+        "docker://perl:5.40.2"
+    params:
+        cluster_log=CLUSTER_LOG / "uncollapse_reads_{sample}.log",
     shell:
         "(perl {input.script} \
         --suffix \
@@ -494,14 +493,14 @@ rule convert_uncollapsed_reads_sam_to_bam:
         maps=INTERMEDIATES_DIR
         / "{sample}"
         / "alignments_intersecting_mirna_uncollapsed.bam",
-    params:
-        cluster_log=CLUSTER_LOG / "convert_uncollapsed_reads_sam_to_bam_{sample}.log",
     log:
         LOCAL_LOG / "convert_uncollapsed_reads_sam_to_bam_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
     conda:
         ENV_DIR / "samtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
+    params:
+        cluster_log=CLUSTER_LOG / "convert_uncollapsed_reads_sam_to_bam_{sample}.log",
     shell:
         "(samtools view -b {input.maps} > {output.maps}) &> {log}"
 
@@ -520,14 +519,14 @@ rule sort_uncollapsed_reads_bam_by_position:
         maps=OUT_DIR
         / "{sample}"
         / "alignments_intersecting_mirna_uncollapsed_sorted.bam",
-    params:
-        cluster_log=CLUSTER_LOG / "sort_uncollapsed_reads_bam_by_position_{sample}.log",
     log:
         LOCAL_LOG / "sort_uncollapsed_reads_bam_by_position_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
     conda:
         ENV_DIR / "samtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
+    params:
+        cluster_log=CLUSTER_LOG / "sort_uncollapsed_reads_bam_by_position_{sample}.log",
     shell:
         "(samtools sort {input.maps} > {output.maps}) &> {log}"
 
@@ -546,13 +545,13 @@ rule index_uncollapsed_reads_bam:
         maps=OUT_DIR
         / "{sample}"
         / "alignments_intersecting_mirna_uncollapsed_sorted.bam.bai",
-    params:
-        cluster_log=CLUSTER_LOG / "index_uncollapsed_reads_bam_{sample}.log",
     log:
         LOCAL_LOG / "index_uncollapsed_reads_bam_{sample}.log",
-    container:
-        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
     conda:
         ENV_DIR / "samtools.yaml"
+    container:
+        "docker://quay.io/biocontainers/samtools:1.21--h96c455f_1"
+    params:
+        cluster_log=CLUSTER_LOG / "index_uncollapsed_reads_bam_{sample}.log",
     shell:
         "(samtools index -b {input.maps} > {output.maps}) &> {log}"

--- a/workflow/scripts/annotate_sam_with_intersecting_features.py
+++ b/workflow/scripts/annotate_sam_with_intersecting_features.py
@@ -169,6 +169,7 @@ Example 4: Feature intersects alignment; using feature's "Alias"
         a new tag in the output SAM record. In this case, instead of using the
         feature `Name` (default), the `Alias` is used.
 """  # noqa: E501
+
 # pylint: enable=line-too-long
 
 import argparse

--- a/workflow/scripts/filter_multimappers.py
+++ b/workflow/scripts/filter_multimappers.py
@@ -82,6 +82,7 @@ Example 3: Add NH tag as read's name suffix
     OUT SAM record:
         read-3_1	0	19	5338	1	15M1I7M	*	0	0	TCAAAACTGAGGGGCTATTTTCT	*	HI:i:1	NH:i:1	NM:i:1	MD:Z:22	RG:Z:A1	YZ:Z:0
 """  # noqa: E501
+
 # pylint: enable=line-too-long
 
 import argparse

--- a/workflow/scripts/mirna_quantification.py
+++ b/workflow/scripts/mirna_quantification.py
@@ -119,6 +119,7 @@ Example 8
     output: hsa-miR-512-3p|0|1|23M|22C0|AAGTGCTGTCATAGCTGAGGTAA	4.333333333333333  6 23
             hsa-miR-512-3p|0|1|23M|3T18C0|AAGGGCTGTCATAGCTGAGGTAA 12.0  8 19
 """  # noqa: E501
+
 # pylint: enable=line-too-long
 
 import argparse

--- a/workflow/scripts/oligomap_output_to_sam_nh_filtered.py
+++ b/workflow/scripts/oligomap_output_to_sam_nh_filtered.py
@@ -67,6 +67,7 @@ Paula Iborra. Zavolan Lab.
 Adapted version of Alessandro Crippa script.
 Refactored and documented by Iris Mestres-Pascual.
 """  # noqa: E501
+
 # pylint: enable=line-too-long
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter

--- a/workflow/scripts/primir_quantification.py
+++ b/workflow/scripts/primir_quantification.py
@@ -159,6 +159,7 @@ Example 5: Columns with feature shifts; using '--feat-extension'
     OUT table:
         hsa-mir-524_-1_+3      2       -1       +3
 """  # noqa: E501
+
 # pylint: enable=line-too-long
 
 import argparse

--- a/workflow/scripts/validate_bedtools_intersect.py
+++ b/workflow/scripts/validate_bedtools_intersect.py
@@ -20,7 +20,6 @@ Exposes:
 - parse_all: a streaming generator of '(line_number, Record)' tuples.
 """
 
-
 import re
 from pathlib import Path
 from typing import Dict, Iterator, Literal, Union


### PR DESCRIPTION
## Description

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

This PR fixes the code style that makes the CI fail after upgrading `black` and `snakefmt` dependencies.

## Conventional Commits

- [x] I made sure that the PR title follows the
  [Conventional Commits][conv-commits] specification

<!--
Changes to workflow input (sample table and/or configs):

* major (add **BREAKING CHANGE:** in the beginning of the PR title)
    * more fields/properties are required
    * existing ones are dropped entirely
* minor (add **feat:** in the beginning of the PR title)
    * optional fields/properties are added
    * required ones are made optional


Changes to workflow outputs:

* major (add **BREAKING CHANGE:** in the beginning of the PR title)
    * changes lead to removal/change of existing outputs (format or location)
* minor (add **feat:** in the beginning of the PR title)
    * additional outputs are generated
    * content (but not format or location) of existing output changes

Everything else: patch
(add any other conventional commit in the beginning of the PR title)
-->

## Checklist

- [x] My code changes follow the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature
      works
- [x] New and existing tests pass locally with my changes and I have not
      reduced the code coverage relative to the previous state
- [ ] I have updated any sections of the project's documentation that are
      affected by the proposed changes

<!--
If for some reason you are unable to tick off all boxes, please leave a comment
explaining the issue you are facing so that we can work on it together.
-->

[conv-commits]: <https://www.conventionalcommits.org/en/v1.0.0/>

## Summary by Sourcery

Reformat Snakemake workflow rules and Python helper scripts to comply with updated black and snakefmt style configurations, ensuring consistent rule section ordering and spacing across mapping, quantification, preparation, and pileup workflows.

Enhancements:
- Normalize ordering of log, conda, container, resources, and params sections within Snakemake rules to match current snakefmt conventions.
- Adjust whitespace and formatting in workflow rule files and Python scripts for compatibility with newer versions of black and snakefmt.
- Update blame-ignore configuration to account for bulk reformatting changes so future git blame remains useful.